### PR TITLE
Make RPC client `&self` and remove infallible error.

### DIFF
--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -345,11 +345,7 @@ where
             let keyspace = keyspace.name().to_string();
             let document = document.clone();
             async move {
-                let channel = self
-                    .node
-                    .network()
-                    .get_or_connect(node)
-                    .map_err(|e| error::StoreError::TransportError(node, e))?;
+                let channel = self.node.network().get_or_connect(node);
 
                 let mut client = ConsistencyClient::<S>::new(clock, channel);
 
@@ -415,11 +411,7 @@ where
             let documents = docs.clone();
             let self_member = self.node.me().clone();
             async move {
-                let channel = self
-                    .node
-                    .network()
-                    .get_or_connect(node)
-                    .map_err(|e| error::StoreError::TransportError(node, e))?;
+                let channel = self.node.network().get_or_connect(node);
 
                 let mut client = ConsistencyClient::<S>::new(clock, channel);
 
@@ -477,11 +469,7 @@ where
             let clock = self.node.clock().clone();
             let keyspace = keyspace.name().to_string();
             async move {
-                let channel = self
-                    .node
-                    .network()
-                    .get_or_connect(node)
-                    .map_err(|e| error::StoreError::TransportError(node, e))?;
+                let channel = self.node.network().get_or_connect(node);
 
                 let mut client = ConsistencyClient::<S>::new(clock, channel);
 
@@ -539,11 +527,7 @@ where
             let keyspace = keyspace.name().to_string();
             let docs = docs.clone();
             async move {
-                let channel = self
-                    .node
-                    .network()
-                    .get_or_connect(node)
-                    .map_err(|e| error::StoreError::TransportError(node, e))?;
+                let channel = self.node.network().get_or_connect(node);
 
                 let mut client = ConsistencyClient::<S>::new(clock, channel);
 

--- a/datacake-eventual-consistency/src/replication/distributor.rs
+++ b/datacake-eventual-consistency/src/replication/distributor.rs
@@ -212,7 +212,7 @@ where
         let node_id = node_id.clone();
         let limiter = limiter.clone();
         let batch = batch.clone();
-        let channel = ctx.network.get_or_connect(addr)?;
+        let channel = ctx.network.get_or_connect(addr);
         let mut client = ConsistencyClient::<S>::new(ctx.clock.clone(), channel);
 
         let task = tokio::spawn(async move {

--- a/datacake-eventual-consistency/src/replication/poller.rs
+++ b/datacake-eventual-consistency/src/replication/poller.rs
@@ -263,7 +263,7 @@ where
         "Getting keyspace changes on remote node.",
     );
 
-    let channel = ctx.network.get_or_connect(target_node_addr)?;
+    let channel = ctx.network.get_or_connect(target_node_addr);
     let mut client = ReplicationClient::<S>::new(ctx.clock().clone(), channel.clone());
     let keyspace_timestamps = client.poll_keyspace().await?;
 
@@ -396,7 +396,7 @@ async fn begin_keyspace_sync<S>(
 where
     S: Storage + Send + Sync + 'static,
 {
-    let channel = ctx.network.get_or_connect(target_rpc_addr)?;
+    let channel = ctx.network.get_or_connect(target_rpc_addr);
     let keyspace = ctx.group.get_or_create_keyspace(&keyspace_name).await;
     let client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
 

--- a/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
+++ b/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
@@ -42,10 +42,7 @@ where
 
     fn get_put_ctx(&self, ctx: Option<Context>) -> Result<Option<PutContext>, Status> {
         let ctx = if let Some(info) = ctx {
-            let remote_rpc_channel = self
-                .network
-                .get_or_connect(info.node_addr)
-                .map_err(Status::internal)?;
+            let remote_rpc_channel = self.network.get_or_connect(info.node_addr);
 
             Some(PutContext {
                 progress: ProgressTracker::default(),

--- a/datacake-node/src/rpc/network.rs
+++ b/datacake-node/src/rpc/network.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -15,11 +14,11 @@ pub struct RpcNetwork {
 
 impl RpcNetwork {
     /// Attempts to get an already existing connection or creates a new connection.
-    pub fn get_or_connect(&self, addr: SocketAddr) -> io::Result<Channel> {
+    pub fn get_or_connect(&self, addr: SocketAddr) -> Channel {
         {
             let guard = self.clients.read();
             if let Some(channel) = guard.get(&addr) {
-                return Ok(channel.clone());
+                return channel.clone();
             }
         }
 
@@ -28,15 +27,15 @@ impl RpcNetwork {
     }
 
     /// Connects to a given address and adds it to the clients.
-    pub fn connect(&self, addr: SocketAddr) -> io::Result<Channel> {
-        let channel = Channel::connect(addr)?;
+    pub fn connect(&self, addr: SocketAddr) -> Channel {
+        let channel = Channel::connect(addr);
 
         {
             let mut guard = self.clients.write();
             guard.insert(addr, channel.clone());
         }
 
-        Ok(channel)
+        channel
     }
 
     /// Removes a client from the network.

--- a/datacake-rpc/src/client.rs
+++ b/datacake-rpc/src/client.rs
@@ -119,10 +119,7 @@ where
     }
 
     /// Sends a message to the server and wait for a reply.
-    pub async fn send<Msg>(
-        &mut self,
-        msg: &Msg,
-    ) -> Result<MessageReply<Svc, Msg>, Status>
+    pub async fn send<Msg>(&self, msg: &Msg) -> Result<MessageReply<Svc, Msg>, Status>
     where
         Msg: Archive + Serialize<AllocSerializer<SCRATCH_SPACE>>,
         Msg::Archived: CheckBytes<DefaultValidator<'static>> + 'static,

--- a/datacake-rpc/src/net/client.rs
+++ b/datacake-rpc/src/net/client.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -19,7 +18,7 @@ pub struct Channel {
 
 impl Channel {
     /// Connects to a remote RPC server.
-    pub fn connect(remote_addr: SocketAddr) -> io::Result<Self> {
+    pub fn connect(remote_addr: SocketAddr) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
         http.set_nodelay(true);
@@ -31,10 +30,10 @@ impl Channel {
             .http2_adaptive_window(true)
             .build(http);
 
-        Ok(Self {
+        Self {
             connection: client,
             remote_addr,
-        })
+        }
     }
 
     /// Sends a message payload the remote server and gets the response

--- a/datacake-rpc/tests/basic.rs
+++ b/datacake-rpc/tests/basic.rs
@@ -47,10 +47,10 @@ async fn test_basic() {
     server.add_service(MyService);
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
-    let mut rpc_client = RpcClient::<MyService>::new(client);
+    let rpc_client = RpcClient::<MyService>::new(client);
 
     let msg1 = MyMessage {
         name: "Bobby".to_string(),

--- a/datacake-rpc/tests/many_messages.rs
+++ b/datacake-rpc/tests/many_messages.rs
@@ -81,10 +81,10 @@ async fn test_multiple_msgs() {
     server.add_service(CountingService::default());
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
-    let mut rpc_client = RpcClient::<CountingService>::new(client);
+    let rpc_client = RpcClient::<CountingService>::new(client);
 
     let msg = IncCounter {
         name: "Bobby".to_string(),

--- a/datacake-rpc/tests/many_services.rs
+++ b/datacake-rpc/tests/many_services.rs
@@ -67,13 +67,13 @@ async fn test_multiple_services() {
     server.add_service(Sub5Service);
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
     let msg = Payload { value: 5 };
 
-    let mut add_client = RpcClient::<Add5Service>::new(client.clone());
-    let mut subtract_client = RpcClient::<Sub5Service>::new(client);
+    let add_client = RpcClient::<Add5Service>::new(client.clone());
+    let subtract_client = RpcClient::<Sub5Service>::new(client);
 
     let resp = add_client.send(&msg).await.unwrap();
     assert_eq!(resp, 10);
@@ -81,7 +81,7 @@ async fn test_multiple_services() {
     let resp = subtract_client.send(&msg).await.unwrap();
     assert_eq!(resp, 0);
 
-    let mut subtract_client = add_client.new_client::<Sub5Service>();
+    let subtract_client = add_client.new_client::<Sub5Service>();
     let resp = subtract_client.send(&msg).await.unwrap();
     assert_eq!(resp, 0);
 }

--- a/datacake-rpc/tests/service_error.rs
+++ b/datacake-rpc/tests/service_error.rs
@@ -47,10 +47,10 @@ async fn test_service_error() {
     server.add_service(MyService);
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
-    let mut rpc_client = RpcClient::<MyService>::new(client);
+    let rpc_client = RpcClient::<MyService>::new(client);
 
     let msg1 = MyMessage {
         name: "Bobby".to_string(),

--- a/datacake-rpc/tests/unknown_service.rs
+++ b/datacake-rpc/tests/unknown_service.rs
@@ -64,13 +64,13 @@ async fn test_unknown_service() {
     server.add_service(Add5Service);
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
     let msg = Payload { value: 5 };
 
-    let mut add_client = RpcClient::<Add5Service>::new(client.clone());
-    let mut subtract_client = RpcClient::<Sub5Service>::new(client);
+    let add_client = RpcClient::<Add5Service>::new(client.clone());
+    let subtract_client = RpcClient::<Sub5Service>::new(client);
 
     let resp = add_client.send(&msg).await.unwrap();
     assert_eq!(resp, 10);
@@ -98,13 +98,13 @@ async fn test_unknown_message() {
     server.add_service(Add5Service);
     println!("Listening to address {}!", addr);
 
-    let client = Channel::connect(addr).unwrap();
+    let client = Channel::connect(addr);
     println!("Connected to address {}!", addr);
 
     let msg = Payload { value: 5 };
 
-    let mut add_client = RpcClient::<Add5Service>::new(client.clone());
-    let mut subtract_client = RpcClient::<Sub5Service>::new(client);
+    let add_client = RpcClient::<Add5Service>::new(client.clone());
+    let subtract_client = RpcClient::<Sub5Service>::new(client);
 
     let resp = add_client.send(&msg).await.unwrap();
     assert_eq!(resp, 10);


### PR DESCRIPTION
Removes the `&mut self` signature from the RPC client and also removes the result signature which was infallible before when calling `connect`