### PR TITLE
Pack data into single `u64` for `HLCTimestamp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-datacake-crdt = { version = "0.3", path = "datacake-crdt", optional = true }
+datacake-crdt = { version = "0.4", path = "datacake-crdt", optional = true }
 datacake-eventual-consistency = { version = "0.2", path = "datacake-eventual-consistency", optional = true }
 datacake-sqlite = { version = "0.2", path = "datacake-sqlite", optional = true }
 datacake-rpc = { version = "0.2", path = "datacake-rpc", optional = true }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
   let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
   let cluster = DatacakeCluster::connect(
-    "node-1",
+    1,
     connection_cfg,
     MemStore::default(),
     DCAwareSelector::default(),

--- a/datacake-crdt/Cargo.toml
+++ b/datacake-crdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datacake-crdt"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A conflict free replicated datatype based on a hybrid logical clock implementation for building eventually consistent data stores."
 license = "MIT"

--- a/datacake-crdt/README.md
+++ b/datacake-crdt/README.md
@@ -8,13 +8,13 @@ which guarantees the timestamp will always be unique and monotonic (providing it
 
 ### Basic Example
 ```rust
-use datacake_crdt::{OrSWotSet, HLCTimestamp, get_unix_timestamp_ms};
+use datacake_crdt::{OrSWotSet, HLCTimestamp};
 
 fn main() {
-    let mut node_a = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+    let mut node_a = HLCTimestamp::now(0, 0);
     
     // Simulating a node begin slightly ahead.
-    let mut node_b = HLCTimestamp::new(get_unix_timestamp_ms() + 5000, 0, 1);
+    let mut node_b = HLCTimestamp::new(node_a.seconds() + 5000, 0, 1);
     
     let mut node_a_set = OrSWotSet::default();
     let mut node_b_set = OrSWotSet::default();
@@ -37,8 +37,8 @@ fn main() {
     node_a_set.merge(node_b_set);
     
     // Set A and B should both see that key `1` has been deleted.
-    assert!(node_a_set.get(&1).is_none(), "Key a was not correctly removed.");
-    assert!(node_b_set.get(&1).is_none(), "Key a was not correctly removed.");
+    assert!(node_a_set.get(&1).is_none(), "Key should be correctly removed.");
+    assert!(node_b_set.get(&1).is_none(), "Key should be correctly removed.");
 }
 ```
 

--- a/datacake-crdt/src/lib.rs
+++ b/datacake-crdt/src/lib.rs
@@ -5,8 +5,11 @@ mod timestamp;
 pub use orswot::BadState;
 pub use orswot::{Key, OrSWotSet, StateChanges};
 pub use timestamp::{
+    get_unix_timestamp,
     get_unix_timestamp_ms,
     HLCTimestamp,
     InvalidFormat,
     TimestampError,
+    COUNTER_MAX,
+    TIMESTAMP_MAX,
 };

--- a/datacake-crdt/src/timestamp.rs
+++ b/datacake-crdt/src/timestamp.rs
@@ -74,6 +74,13 @@ impl HLCTimestamp {
         Self(pack(seconds, counter, node))
     }
 
+    /// Create a new [HLCTimestamp].
+    ///
+    /// This internally gets the current UNIX timestamp in seconds.
+    pub fn now(counter: u32, node: u8) -> Self {
+        Self::new(get_unix_timestamp(), counter, node)
+    }
+
     #[inline]
     pub fn node(&self) -> u8 {
         (self.0 & 0xFF).try_into().unwrap_or_default()

--- a/datacake-crdt/src/timestamp.rs
+++ b/datacake-crdt/src/timestamp.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -9,10 +8,12 @@ use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-support")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-/// Maximum physical clock drift allowed, in ms
-const MAX_DRIFT_MS: u64 = 60_000;
+/// Maximum physical clock drift allowed, in s
+const MAX_DRIFT_S: u64 = 4_100;
+pub const COUNTER_MAX: u32 = (1 << 22) - 1;
+pub const TIMESTAMP_MAX: u64 = (1 << 34) - 1;
 
-#[derive(Debug, Hash, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Hash, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(C)]
 #[cfg_attr(feature = "rkyv-support", derive(Serialize, Deserialize, Archive))]
 #[cfg_attr(feature = "rkyv-support", archive(compare(PartialEq)))]
@@ -31,14 +32,19 @@ const MAX_DRIFT_MS: u64 = 60_000;
 /// The timestamp doubles as a lock which can be used to maintain and consistently
 /// unique and monotonic clock.
 ///
+/// This internally is a packed `u64` integer and breaks down as the following:
+/// - 34 bits for timestamp (seconds)
+/// - 22 bits for counter
+/// - 8 bits for node id
+///
 /// ```
-/// use datacake_crdt::{HLCTimestamp, get_unix_timestamp_ms};
+/// use datacake_crdt::{HLCTimestamp, get_unix_timestamp};
 ///
 /// // Let's make two clocks, but we'll refer to them as our nodes, node-a and node-b.
-/// let mut node_a = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+/// let mut node_a = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
 ///
 /// // Node-b has a clock drift of 5 seconds.
-/// let mut node_b = HLCTimestamp::new(get_unix_timestamp_ms() + 5000, 0, 1);
+/// let mut node_b = HLCTimestamp::new(get_unix_timestamp() + 5, 0, 1);
 ///
 /// // Node-b sends a payload with a new timestamp which we get by calling `send()`.
 /// // this makes sure our timestamp is unique and monotonic.
@@ -48,82 +54,67 @@ const MAX_DRIFT_MS: u64 = 60_000;
 /// // This was node-a is also unique and monotonic.
 /// node_a.recv(&timestamp).unwrap();
 /// ```
-pub struct HLCTimestamp {
-    millis: u64,
-    counter: u16,
-    node: u32,
-}
-
-impl PartialOrd<Self> for HLCTimestamp {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for HLCTimestamp {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // The node id is used as a tie breaker.
-        (self.millis, self.counter, self.node).cmp(&(
-            other.millis,
-            other.counter,
-            other.node,
-        ))
-    }
-}
+pub struct HLCTimestamp(u64);
 
 impl HLCTimestamp {
     /// Create a new [HLCTimestamp].
     ///
-    /// You may wish to use [get_unix_timestamp_ms] to get a unix timestamp
+    /// You may wish to use [get_unix_timestamp] to get a unix timestamp
     /// suitable for the initial clock state.
-    pub fn new(millis: u64, counter: u16, node: u32) -> Self {
-        Self {
-            millis,
-            counter,
-            node,
-        }
+    pub const fn new(seconds: u64, counter: u32, node: u8) -> Self {
+        assert!(
+            seconds <= TIMESTAMP_MAX,
+            "Timestamp cannot go beyond the maximum capacity of 34 bits. Has 500 years elapsed?",
+        );
+        assert!(
+            counter <= COUNTER_MAX,
+            "Counter cannot go beyond the maximum capacity of 22 bits. Has 500 years elapsed?",
+        );
+
+        Self(pack(seconds, counter, node))
     }
 
     #[inline]
-    pub fn node(&self) -> u32 {
-        self.node
+    pub fn node(&self) -> u8 {
+        (self.0 & 0xFF).try_into().unwrap_or_default()
     }
 
     #[inline]
-    pub fn counter(&self) -> u16 {
-        self.counter
+    pub fn counter(&self) -> u32 {
+        ((self.0 >> 8) & 0b1111111111111111111111) // 22 bits explicitly.
+            .try_into()
+            .unwrap_or_default()
     }
 
     #[inline]
-    pub fn millis(&self) -> u64 {
-        self.millis
+    pub fn seconds(&self) -> u64 {
+        self.0 >> 30
     }
 
     /// Timestamp send. Generates a unique, monotonic timestamp suitable
     /// for transmission to another system.
     pub fn send(&mut self) -> Result<Self, TimestampError> {
-        let ts = get_unix_timestamp_ms();
+        let ts = get_unix_timestamp();
 
-        let ts_old = self.millis;
-        let c_old = self.counter;
+        let ts_old = self.seconds();
+        let c_old = self.counter();
 
         // Calculate the next logical time and counter
         // * ensure that the logical time never goes backward
         // * increment the counter if phys time does not advance
         let ts_new = cmp::max(ts_old, ts);
 
-        if ts_new.saturating_sub(ts) > MAX_DRIFT_MS {
+        if ts_new.saturating_sub(ts) > MAX_DRIFT_S {
             return Err(TimestampError::ClockDrift);
         }
 
         let c_new = if ts_old == ts_new {
-            c_old.checked_add(1).ok_or(TimestampError::Overflow)?
+            safe_inc_counter(c_old).ok_or(TimestampError::Overflow)?
         } else {
             0
         };
 
-        self.millis = ts_new;
-        self.counter = c_new;
+        self.0 = pack(ts_new, c_new, self.node());
 
         Ok(*self)
     }
@@ -132,24 +123,24 @@ impl HLCTimestamp {
     /// system with the local time-global uniqueness and monotonicity are
     /// preserved.
     pub fn recv(&mut self, msg: &Self) -> Result<Self, TimestampError> {
-        if self.node == msg.node {
-            return Err(TimestampError::DuplicatedNode(msg.node));
+        if self.node() == msg.node() {
+            return Err(TimestampError::DuplicatedNode(msg.node()));
         }
 
-        let ts = get_unix_timestamp_ms();
+        let ts = get_unix_timestamp();
 
         // Unpack the message wall time/counter
-        let ts_msg = msg.millis;
-        let c_msg = msg.counter;
+        let ts_msg = msg.seconds();
+        let c_msg = msg.counter();
 
         // Assert the remote clock drift
-        if ts_msg.saturating_sub(ts) > MAX_DRIFT_MS {
+        if ts_msg.saturating_sub(ts) > MAX_DRIFT_S {
             return Err(TimestampError::ClockDrift);
         }
 
         // Unpack the clock.timestamp logical time and counter
-        let ts_old = self.millis;
-        let c_old = self.counter;
+        let ts_old = self.seconds();
+        let c_old = self.counter();
 
         // Calculate the next logical time and counter.
         // Ensure that the logical time never goes backward;
@@ -160,28 +151,26 @@ impl HLCTimestamp {
 
         let ts_new = cmp::max(cmp::max(ts_old, ts), ts_msg);
 
-        if ts_new.saturating_sub(ts) > MAX_DRIFT_MS {
+        if ts_new.saturating_sub(ts) > MAX_DRIFT_S {
             return Err(TimestampError::ClockDrift);
         }
 
         let c_new = {
             if ts_new == ts_old && ts_new == ts_msg {
-                cmp::max(c_old, c_msg)
-                    .checked_add(1)
+                safe_inc_counter(cmp::max(c_old, c_msg))
                     .ok_or(TimestampError::Overflow)?
             } else if ts_new == ts_old {
-                c_old.checked_add(1).ok_or(TimestampError::Overflow)?
+                safe_inc_counter(c_old).ok_or(TimestampError::Overflow)?
             } else if ts_new == ts_msg {
-                c_msg.checked_add(1).ok_or(TimestampError::Overflow)?
+                safe_inc_counter(c_msg).ok_or(TimestampError::Overflow)?
             } else {
                 0
             }
         };
 
-        self.millis = ts_new;
-        self.counter = c_new;
+        self.0 = pack(ts_new, c_new, self.node());
 
-        Ok(Self::new(self.millis, self.counter, msg.node))
+        Ok(Self::new(self.seconds(), self.counter(), msg.node()))
     }
 }
 
@@ -189,8 +178,10 @@ impl Display for HLCTimestamp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}-{:0>4X}-{:0>16}",
-            self.millis, self.counter, self.node
+            "{}-{:0>6X}-{:0>4}",
+            self.seconds(),
+            self.counter(),
+            self.node()
         )
     }
 }
@@ -207,14 +198,32 @@ impl FromStr for HLCTimestamp {
             .ok_or(InvalidFormat)?;
         let counter = splits
             .next()
-            .and_then(|v| u16::from_str_radix(v, 16).ok())
+            .and_then(|v| u32::from_str_radix(v, 16).ok())
             .ok_or(InvalidFormat)?;
         let node = splits
             .next()
-            .and_then(|v| v.parse::<u32>().ok())
+            .and_then(|v| v.parse::<u8>().ok())
             .ok_or(InvalidFormat)?;
 
         Ok(Self::new(millis, counter, node))
+    }
+}
+
+/// Packs the given values into
+const fn pack(seconds: u64, counter: u32, node: u8) -> u64 {
+    let counter = counter as u64;
+    let node = node as u64;
+
+    (seconds << 30) | (counter << 8) | node
+}
+
+/// Increments the counter value respecting the maximum
+/// allowed value which is safe to pack.
+const fn safe_inc_counter(v: u32) -> Option<u32> {
+    if (v + 1) > COUNTER_MAX {
+        None
+    } else {
+        Some(v + 1)
     }
 }
 
@@ -226,7 +235,7 @@ pub struct InvalidFormat;
 #[derive(Debug, thiserror::Error)]
 pub enum TimestampError {
     #[error("Expected a different unique node, got node with the same id. {0:?}")]
-    DuplicatedNode(u32),
+    DuplicatedNode(u8),
 
     #[error("The clock drift difference is too high to be used.")]
     ClockDrift,
@@ -243,13 +252,23 @@ pub fn get_unix_timestamp_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Get the current time since the [DATACAKE_EPOCH] in seconds.
+pub fn get_unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const TEST_TS: u64 = 1;
+
     #[test]
     fn test_parse() {
-        let ts = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+        let ts = HLCTimestamp::new(TEST_TS, 0, 0);
 
         let str_ts = ts.to_string();
         HLCTimestamp::from_str(&str_ts).expect("Parse timestamp");
@@ -257,8 +276,8 @@ mod tests {
 
     #[test]
     fn test_same_node_error() {
-        let mut ts1 = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
-        let ts2 = HLCTimestamp::new(get_unix_timestamp_ms(), 1, 0);
+        let mut ts1 = HLCTimestamp::new(TEST_TS, 0, 0);
+        let ts2 = HLCTimestamp::new(TEST_TS, 1, 0);
 
         assert!(matches!(
             ts1.recv(&ts2),
@@ -268,22 +287,79 @@ mod tests {
 
     #[test]
     fn test_clock_drift_error() {
-        let mut ts1 = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
-        let ts2 = HLCTimestamp::new(ts1.millis + MAX_DRIFT_MS + 100, 0, 1);
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
+        let ts2 = HLCTimestamp::new(ts1.seconds() + MAX_DRIFT_S + 1000, 0, 1);
 
-        assert!(matches!(ts1.recv(&ts2), Err(TimestampError::ClockDrift),));
+        assert!(matches!(ts1.recv(&ts2), Err(TimestampError::ClockDrift)));
 
-        let mut ts =
-            HLCTimestamp::new(get_unix_timestamp_ms() + MAX_DRIFT_MS + 100, 0, 1);
+        let mut ts = HLCTimestamp::new(get_unix_timestamp() + MAX_DRIFT_S + 1000, 0, 1);
         assert!(matches!(ts.send(), Err(TimestampError::ClockDrift)));
     }
 
     #[test]
     fn test_clock_overflow_error() {
-        let mut ts1 = HLCTimestamp::new(get_unix_timestamp_ms(), u16::MAX, 0);
-        let ts2 = HLCTimestamp::new(ts1.millis, u16::MAX, 1);
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), COUNTER_MAX, 0);
+        let ts2 = HLCTimestamp::new(ts1.seconds(), COUNTER_MAX, 1);
 
-        assert!(matches!(ts1.recv(&ts2), Err(TimestampError::Overflow),))
+        assert!(matches!(ts1.recv(&ts2), Err(TimestampError::Overflow)));
+    }
+
+    #[test]
+    fn test_timestamp_send() {
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
+        let ts2 = ts1.send().unwrap();
+        assert_eq!(ts1.seconds(), ts2.seconds(), "Logical clock should match.");
+        assert_eq!(ts1.counter(), 1, "Counter should be incremented for ts1.");
+        assert_eq!(ts2.counter(), 1, "Counter should be incremented for ts2.");
+    }
+
+    #[test]
+    fn test_timestamp_recv() {
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
+        let mut ts2 = HLCTimestamp::new(ts1.seconds(), 3, 1);
+
+        let ts3 = ts1.recv(&ts2).unwrap();
+
+        // Ts3 is just a copy of the clock itself at this point.
+        assert_eq!(ts1.seconds(), ts3.seconds());
+        assert_eq!(ts1.counter(), ts3.counter());
+
+        assert_eq!(ts3.counter(), 4); // seconds stay the same, our counter should increment.
+
+        let ts4 = ts2.recv(&ts1).unwrap();
+        assert_eq!(ts2.seconds(), ts4.seconds());
+        assert_eq!(ts2.counter(), ts4.counter());
+        assert_eq!(ts4.counter(), 5); // seconds stay the same, our counter should increment.
+
+        assert!(ts1 < ts2);
+        assert!(ts3 < ts4);
+    }
+
+    #[test]
+    fn test_timestamp_ordering() {
+        let ts1 = HLCTimestamp::new(TEST_TS, 0, 0);
+        let ts2 = HLCTimestamp::new(TEST_TS, 1, 0);
+        let ts3 = HLCTimestamp::new(TEST_TS, 2, 0);
+        assert!(ts1 < ts2);
+        assert!(ts2 < ts3);
+
+        let ts1 = HLCTimestamp::new(TEST_TS, 0, 0);
+        let ts2 = HLCTimestamp::new(TEST_TS, 0, 1);
+        assert!(ts1 < ts2);
+
+        let ts1 = HLCTimestamp::new(TEST_TS, 0, 1);
+        let ts2 = HLCTimestamp::new(TEST_TS + 1, 0, 0);
+        assert!(ts1 < ts2);
+
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), 0, 1);
+        let ts2 = ts1.send().unwrap();
+        let ts3 = ts1.send().unwrap();
+        assert!(ts2 < ts3);
+
+        let mut ts1 = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
+        let ts2 = HLCTimestamp::new(ts1.seconds(), 1, 1);
+        let _ts3 = ts1.recv(&ts2).unwrap();
+        assert!(ts1 > ts2);
     }
 }
 
@@ -293,13 +369,13 @@ mod rkyv_tests {
 
     #[test]
     fn test_serialize() {
-        let ts = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+        let ts = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
         rkyv::to_bytes::<_, 1024>(&ts).expect("Serialize timestamp OK");
     }
 
     #[test]
     fn test_deserialize() {
-        let ts = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+        let ts = HLCTimestamp::new(get_unix_timestamp(), 0, 0);
         let buffer = rkyv::to_bytes::<_, 1024>(&ts).expect("Serialize timestamp OK");
 
         let new_ts: HLCTimestamp =

--- a/datacake-crdt/src/timestamp.rs
+++ b/datacake-crdt/src/timestamp.rs
@@ -82,11 +82,13 @@ impl HLCTimestamp {
     }
 
     #[inline]
+    /// The node ID which produced this timestamp
     pub fn node(&self) -> u8 {
         (self.0 & 0xFF).try_into().unwrap_or_default()
     }
 
     #[inline]
+    /// The counter used to keep the clock monotonic.
     pub fn counter(&self) -> u32 {
         ((self.0 >> 8) & 0b1111111111111111111111) // 22 bits explicitly.
             .try_into()
@@ -94,8 +96,25 @@ impl HLCTimestamp {
     }
 
     #[inline]
+    /// The UNIX timestamp.
     pub fn seconds(&self) -> u64 {
         self.0 >> 30
+    }
+
+    #[inline]
+    /// The timestamp as it's raw `u64`.
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    /// Creates a new timestamp from a given `u64`.
+    ///
+    /// WARNING:
+    ///     It is *your* responsibility that the provided value is a correctly
+    ///     packed number, otherwise your timestamp will spit out gibberish.
+    pub fn from_u64(val: u64) -> Self {
+        Self(val)
     }
 
     /// Timestamp send. Generates a unique, monotonic timestamp suitable

--- a/datacake-eventual-consistency/Cargo.toml
+++ b/datacake-eventual-consistency/Cargo.toml
@@ -34,7 +34,7 @@ rkyv = { version = "0.7.9", features = ["validation"] }
 
 datacake-rpc = { path = "../datacake-rpc", version = "0.2" }
 datacake-node = { path = "../datacake-node", version = "0.1" }
-datacake-crdt = { path = "../datacake-crdt", version = "0.3", features = ["rkyv-support"] }
+datacake-crdt = { path = "../datacake-crdt", version = "0.4", features = ["rkyv-support"] }
 
 [features]
 test-utils = []

--- a/datacake-eventual-consistency/src/keyspace/actor.rs
+++ b/datacake-eventual-consistency/src/keyspace/actor.rs
@@ -252,7 +252,7 @@ where
 mod tests {
     use std::cmp::Reverse;
 
-    use datacake_crdt::get_unix_timestamp_ms;
+    use datacake_crdt::get_unix_timestamp;
 
     use super::*;
     use crate::core::DocumentMetadata;
@@ -327,7 +327,7 @@ mod tests {
     async fn test_on_set_old_ts() {
         let clock = Clock::new(0);
 
-        let old_ts = HLCTimestamp::new(get_unix_timestamp_ms() - 3_700_000, 0, 0);
+        let old_ts = HLCTimestamp::new(get_unix_timestamp() - 3_700, 0, 0);
         let doc_1 = Document::new(1, clock.get_time().await, b"Hello, world 1".to_vec());
         let doc_2 = Document::new(2, clock.get_time().await, b"Hello, world 2".to_vec());
         let doc_3 = Document::new(3, old_ts, b"Hello, world 3".to_vec());
@@ -415,7 +415,7 @@ mod tests {
     async fn test_on_multi_set_old_ts() {
         let clock = Clock::new(0);
 
-        let old_ts = HLCTimestamp::new(get_unix_timestamp_ms() - 3_700_000, 0, 0);
+        let old_ts = HLCTimestamp::new(get_unix_timestamp() - 3_700, 0, 0);
         let doc_1 = Document::new(1, clock.get_time().await, b"Hello, world 1".to_vec());
         let doc_2 = Document::new(2, clock.get_time().await, b"Hello, world 2".to_vec());
         let doc_3 = Document::new(3, clock.get_time().await, b"Hello, world 3".to_vec());
@@ -478,7 +478,7 @@ mod tests {
     async fn test_on_multi_set_unordered_events() {
         let clock = Clock::new(0);
 
-        let old_ts = HLCTimestamp::new(get_unix_timestamp_ms() - 3_700_000, 0, 0);
+        let old_ts = HLCTimestamp::new(get_unix_timestamp() - 3_700, 0, 0);
         let doc_1 = Document::new(1, clock.get_time().await, b"Hello, world 1".to_vec());
         let doc_2 = Document::new(2, clock.get_time().await, b"Hello, world 2".to_vec());
         let doc_3 = Document::new(3, clock.get_time().await, b"Hello, world 3".to_vec());
@@ -676,12 +676,12 @@ mod tests {
         keyspace.state.insert_with_source(
             1,
             5,
-            HLCTimestamp::new(get_unix_timestamp_ms() + 3_700_000, 0, 0),
+            HLCTimestamp::new(get_unix_timestamp() + 3_700, 0, 0),
         );
         keyspace.state.insert_with_source(
             0,
             2,
-            HLCTimestamp::new(get_unix_timestamp_ms() + 3_700_000, 1, 0),
+            HLCTimestamp::new(get_unix_timestamp() + 3_700, 1, 0),
         );
 
         let mut changes = keyspace.state.purge_old_deletes();

--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -155,7 +155,7 @@ where
         let task_ctx = TaskServiceContext {
             clock: node.clock().clone(),
             network: node.network().clone(),
-            local_node_id: Cow::Owned(node.me().node_id.clone()),
+            local_node_id: node.me().node_id,
             public_node_addr: node.me().public_addr,
         };
         let replication_ctx = ReplicationCycleContext {
@@ -357,7 +357,7 @@ where
                     .put(
                         keyspace,
                         document,
-                        &self.node.me().node_id,
+                        self.node.me().node_id,
                         self.node.me().public_addr,
                     )
                     .await
@@ -427,7 +427,7 @@ where
                     .multi_put(
                         keyspace,
                         documents.into_iter(),
-                        &self_member.node_id,
+                        self_member.node_id,
                         self_member.public_addr,
                     )
                     .await

--- a/datacake-eventual-consistency/src/rpc/client.rs
+++ b/datacake-eventual-consistency/src/rpc/client.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::net::SocketAddr;
 
 use datacake_crdt::{HLCTimestamp, Key, OrSWotSet};
-use datacake_node::Clock;
+use datacake_node::{Clock, NodeId};
 use datacake_rpc::{Channel, RpcClient, Status};
 use rkyv::AlignedVec;
 
@@ -54,7 +54,7 @@ where
         &mut self,
         keyspace: impl Into<String>,
         document: Document,
-        node_id: &str,
+        node_id: NodeId,
         node_addr: SocketAddr,
     ) -> Result<(), Status> {
         let timestamp = self.clock.get_time().await;
@@ -63,10 +63,7 @@ where
             .send(&PutPayload {
                 keyspace: keyspace.into(),
                 document,
-                ctx: Some(Context {
-                    node_id: node_id.to_string(),
-                    node_addr,
-                }),
+                ctx: Some(Context { node_id, node_addr }),
                 timestamp,
             })
             .await?
@@ -81,7 +78,7 @@ where
         &mut self,
         keyspace: impl Into<String>,
         documents: impl Iterator<Item = Document>,
-        node_id: &str,
+        node_id: NodeId,
         node_addr: SocketAddr,
     ) -> Result<(), Status> {
         let timestamp = self.clock.get_time().await;
@@ -90,10 +87,7 @@ where
             .send(&MultiPutPayload {
                 keyspace: keyspace.into(),
                 documents: documents.collect(),
-                ctx: Some(Context {
-                    node_id: node_id.to_string(),
-                    node_addr,
-                }),
+                ctx: Some(Context { node_id, node_addr }),
                 timestamp,
             })
             .await?

--- a/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
+++ b/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
@@ -1,10 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 
 use bytecheck::CheckBytes;
 use datacake_crdt::HLCTimestamp;
-use datacake_node::RpcNetwork;
+use datacake_node::{NodeId, RpcNetwork};
 use datacake_rpc::{Handler, Request, RpcService, ServiceRegistry, Status};
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -49,7 +48,7 @@ where
 
             Some(PutContext {
                 progress: ProgressTracker::default(),
-                remote_node_id: Cow::Owned(info.node_id),
+                remote_node_id: info.node_id,
                 remote_addr: info.node_addr,
                 remote_rpc_channel,
             })
@@ -282,7 +281,7 @@ pub struct BatchPayload {
 #[derive(Serialize, Deserialize, Archive, Debug)]
 #[archive_attr(derive(CheckBytes))]
 pub struct Context {
-    pub node_id: String,
+    pub node_id: NodeId,
     pub node_addr: SocketAddr,
 }
 

--- a/datacake-eventual-consistency/src/storage.rs
+++ b/datacake-eventual-consistency/src/storage.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -7,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use datacake_crdt::{HLCTimestamp, Key};
+use datacake_node::NodeId;
 use datacake_rpc::Channel;
 
 use crate::core::{Document, DocumentMetadata};
@@ -88,7 +88,7 @@ pub struct PutContext {
     pub(crate) progress: ProgressTracker,
 
     // Info relating to the remote node.
-    pub(crate) remote_node_id: Cow<'static, str>,
+    pub(crate) remote_node_id: NodeId,
     pub(crate) remote_addr: SocketAddr,
     pub(crate) remote_rpc_channel: Channel,
 }
@@ -105,8 +105,8 @@ impl PutContext {
 
     #[inline]
     /// The unique ID of the remote node.
-    pub fn remote_node_id(&self) -> &str {
-        self.remote_node_id.as_ref()
+    pub fn remote_node_id(&self) -> NodeId {
+        self.remote_node_id
     }
 
     #[inline]
@@ -348,7 +348,7 @@ pub mod test_suite {
     use std::collections::HashSet;
     use std::hash::Hash;
 
-    use datacake_crdt::{get_unix_timestamp_ms, HLCTimestamp, Key};
+    use datacake_crdt::{HLCTimestamp, Key};
 
     use crate::core::Document;
     use crate::storage::Storage;
@@ -363,7 +363,7 @@ pub mod test_suite {
     }
 
     pub async fn run_test_suite<S: Storage + Send + Sync + 'static>(storage: S) {
-        let mut clock = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
+        let mut clock = HLCTimestamp::now(0, 0);
         info!("Starting test suite for storage: {}", type_name::<S>());
 
         let storage = InstrumentedStorage(storage);

--- a/datacake-eventual-consistency/tests/basic_connect.rs
+++ b/datacake-eventual-consistency/tests/basic_connect.rs
@@ -12,7 +12,7 @@ async fn test_basic_connect() -> anyhow::Result<()> {
     let addr = "127.0.0.1:8000".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
         .connect()
         .await?;
     let _store = node

--- a/datacake-eventual-consistency/tests/dynamic_membership.rs
+++ b/datacake-eventual-consistency/tests/dynamic_membership.rs
@@ -33,21 +33,19 @@ pub async fn test_member_join() -> anyhow::Result<()> {
         [node_1_addr.to_string(), node_2_addr.to_string()],
     );
 
-    let node_1 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", node_1_connection_cfg)
-            .connect()
-            .await?;
-    let node_2 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-2", node_2_connection_cfg)
-            .connect()
-            .await?;
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, node_1_connection_cfg)
+        .connect()
+        .await?;
+    let node_2 = DatacakeNodeBuilder::<DCAwareSelector>::new(2, node_2_connection_cfg)
+        .connect()
+        .await?;
 
     node_1
-        .wait_for_nodes(&["node-2"], Duration::from_secs(30))
+        .wait_for_nodes(&[2], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     let store_1 = node_1
@@ -100,12 +98,11 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     assert_eq!(doc.data(), b"Hello, world from node-2");
 
     // Node-3 joins the cluster.
-    let node_3 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-3", node_3_connection_cfg)
-            .connect()
-            .await?;
+    let node_3 = DatacakeNodeBuilder::<DCAwareSelector>::new(3, node_3_connection_cfg)
+        .connect()
+        .await?;
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(60))
+        .wait_for_nodes(&[2, 1], Duration::from_secs(60))
         .await
         .expect("Nodes should connect within timeout.");
     let store_3 = node_3
@@ -124,7 +121,7 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     assert!(doc.is_none());
 
     node_3
-        .wait_for_nodes(&["node-1", "node-2"], Duration::from_secs(30))
+        .wait_for_nodes(&[1, 2], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-eventual-consistency/tests/multi_node_cluster.rs
+++ b/datacake-eventual-consistency/tests/multi_node_cluster.rs
@@ -353,12 +353,6 @@ async fn test_async_operations() -> anyhow::Result<()> {
 }
 
 async fn connect_cluster(addrs: [SocketAddr; 3]) -> [DatacakeNode; 3] {
-    dbg!(
-        crc32fast::hash("node-1".as_bytes()),
-        crc32fast::hash("node-2".as_bytes()),
-        crc32fast::hash("node-3".as_bytes())
-    );
-
     let node_1_connection_cfg = ConnectionConfig::new(
         addrs[0],
         addrs[0],
@@ -375,32 +369,29 @@ async fn connect_cluster(addrs: [SocketAddr; 3]) -> [DatacakeNode; 3] {
         [addrs[0].to_string(), addrs[1].to_string()],
     );
 
-    let node_1 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", node_1_connection_cfg)
-            .connect()
-            .await
-            .unwrap();
-    let node_2 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-2", node_2_connection_cfg)
-            .connect()
-            .await
-            .unwrap();
-    let node_3 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-3", node_3_connection_cfg)
-            .connect()
-            .await
-            .unwrap();
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, node_1_connection_cfg)
+        .connect()
+        .await
+        .unwrap();
+    let node_2 = DatacakeNodeBuilder::<DCAwareSelector>::new(2, node_2_connection_cfg)
+        .connect()
+        .await
+        .unwrap();
+    let node_3 = DatacakeNodeBuilder::<DCAwareSelector>::new(3, node_3_connection_cfg)
+        .connect()
+        .await
+        .unwrap();
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(60))
+        .wait_for_nodes(&[2, 3], Duration::from_secs(60))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-3", "node-1"], Duration::from_secs(60))
+        .wait_for_nodes(&[3, 1], Duration::from_secs(60))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(60))
+        .wait_for_nodes(&[2, 1], Duration::from_secs(60))
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-eventual-consistency/tests/multiple_keyspace.rs
+++ b/datacake-eventual-consistency/tests/multiple_keyspace.rs
@@ -22,7 +22,7 @@ async fn test_single_node() -> anyhow::Result<()> {
     let connection_cfg =
         ConnectionConfig::new(node_addr, node_addr, Vec::<String>::new());
 
-    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", connection_cfg)
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
         .connect()
         .await?;
     let store_1 = node_1
@@ -89,29 +89,26 @@ async fn test_multi_node() -> anyhow::Result<()> {
         [node_1_addr.to_string(), node_2_addr.to_string()],
     );
 
-    let node_1 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", node_1_connection_cfg)
-            .connect()
-            .await?;
-    let node_2 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-2", node_2_connection_cfg)
-            .connect()
-            .await?;
-    let node_3 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-3", node_3_connection_cfg)
-            .connect()
-            .await?;
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, node_1_connection_cfg)
+        .connect()
+        .await?;
+    let node_2 = DatacakeNodeBuilder::<DCAwareSelector>::new(2, node_2_connection_cfg)
+        .connect()
+        .await?;
+    let node_3 = DatacakeNodeBuilder::<DCAwareSelector>::new(3, node_3_connection_cfg)
+        .connect()
+        .await?;
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[2, 3], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-3", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[3, 1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[2, 1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-eventual-consistency/tests/single_node_cluster.rs
+++ b/datacake-eventual-consistency/tests/single_node_cluster.rs
@@ -198,7 +198,7 @@ async fn test_single_node_cluster_bulk_op_with_keyspace_handle() -> anyhow::Resu
 async fn create_store(addr: &str) -> EventuallyConsistentStore<MemStore> {
     let addr = addr.parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
         .connect()
         .await
         .expect("Connect node.");

--- a/datacake-node/Cargo.toml
+++ b/datacake-node/Cargo.toml
@@ -19,7 +19,7 @@ crc32fast = "1.3.2"
 bytecheck = "0.6.9"
 
 datacake-rpc = { version = "0.2", path = "../datacake-rpc" }
-datacake-crdt = { version = "0.3", path = "../datacake-crdt", features = ["rkyv-support"] }
+datacake-crdt = { version = "0.4", path = "../datacake-crdt", features = ["rkyv-support"] }
 chitchat = { version = "0.5.1", package  = "datacake-chitchat-fork" }
 tokio = { version = "1", default-features = false, features = ["sync", "time"] }
 rkyv = { version = "0.7.39", features = ["validation"] }

--- a/datacake-node/tests/membership.rs
+++ b/datacake-node/tests/membership.rs
@@ -21,21 +21,19 @@ pub async fn test_member_join() -> anyhow::Result<()> {
         [node_1_addr.to_string(), node_2_addr.to_string()],
     );
 
-    let node_1 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", node_1_connection_cfg)
-            .connect()
-            .await?;
-    let node_2 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-2", node_2_connection_cfg)
-            .connect()
-            .await?;
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, node_1_connection_cfg)
+        .connect()
+        .await?;
+    let node_2 = DatacakeNodeBuilder::<DCAwareSelector>::new(2, node_2_connection_cfg)
+        .connect()
+        .await?;
 
     node_1
-        .wait_for_nodes(&["node-2"], Duration::from_secs(30))
+        .wait_for_nodes(&[2], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -49,13 +47,12 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     assert_eq!(stats.num_live_members(), 2);
     assert_eq!(stats.num_dead_members(), 0);
 
-    let node_3 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-3", node_3_connection_cfg)
-            .connect()
-            .await?;
+    let node_3 = DatacakeNodeBuilder::<DCAwareSelector>::new(3, node_3_connection_cfg)
+        .connect()
+        .await?;
 
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[2, 1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -100,29 +97,26 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
         [node_1_addr.to_string(), node_2_addr.to_string()],
     );
 
-    let node_1 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", node_1_connection_cfg)
-            .connect()
-            .await?;
-    let node_2 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-2", node_2_connection_cfg)
-            .connect()
-            .await?;
-    let node_3 =
-        DatacakeNodeBuilder::<DCAwareSelector>::new("node-3", node_3_connection_cfg)
-            .connect()
-            .await?;
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, node_1_connection_cfg)
+        .connect()
+        .await?;
+    let node_2 = DatacakeNodeBuilder::<DCAwareSelector>::new(2, node_2_connection_cfg)
+        .connect()
+        .await?;
+    let node_3 = DatacakeNodeBuilder::<DCAwareSelector>::new(3, node_3_connection_cfg)
+        .connect()
+        .await?;
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[2, 3], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-1", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[1, 3], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[2, 1], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-sqlite/Cargo.toml
+++ b/datacake-sqlite/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "1"
 
 tokio = { version = "1", default-features = false, features = ["rt"] }
 
-datacake-crdt = { version = "0.3", path = "../datacake-crdt" }
+datacake-crdt = { version = "0.4", path = "../datacake-crdt" }
 datacake-eventual-consistency = { version = "0.2", path = "../datacake-eventual-consistency" }
 
 [features]

--- a/datacake-sqlite/tests/basic_cluster.rs
+++ b/datacake-sqlite/tests/basic_cluster.rs
@@ -21,7 +21,7 @@ async fn test_basic_sqlite_cluster() -> Result<()> {
     let addr = "127.0.0.1:9000".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
         .connect()
         .await?;
     let store = node

--- a/examples/replicated-kv/README.md
+++ b/examples/replicated-kv/README.md
@@ -5,7 +5,7 @@ This is a nice little example of a KV store implemented as two basic HTTP endpoi
 ## Running
 ### Single node cluster
 ```shell
-cargo run --release -- --node-id "node-1" --data-dir "./my-data"
+cargo run --release -- --node-id 1 --data-dir "./my-data"
 ```
 
 This will spawn a single node with an ID of `node-1` and store the data in the `my-data` directory which will be
@@ -14,9 +14,9 @@ created if it doesn't already exist.
 
 ### 3 node cluster
 ```shell
-cargo run --release -- --node-id "node-1" --data-dir "./my-data/node-1-data --rest-listen-addr 127.0.0.1:8000 --cluster-listen-addr 127.0.0.1:8001 --seed 127.0.0.1:8003 --seed 127.0.0.1:8005"
-cargo run --release -- --node-id "node-2" --data-dir "./my-data/node-2-data --rest-listen-addr 127.0.0.1:8002 --cluster-listen-addr 127.0.0.1:8003 --seed 127.0.0.1:8001 --seed 127.0.0.1:8005"
-cargo run --release -- --node-id "node-3" --data-dir "./my-data/node-3-data --rest-listen-addr 127.0.0.1:8004 --cluster-listen-addr 127.0.0.1:8005 --seed 127.0.0.1:8001 --seed 127.0.0.1:8003"
+cargo run --release -- --node-id 1 --data-dir "./my-data/node-1-data --rest-listen-addr 127.0.0.1:8000 --cluster-listen-addr 127.0.0.1:8001 --seed 127.0.0.1:8003 --seed 127.0.0.1:8005"
+cargo run --release -- --node-id 2 --data-dir "./my-data/node-2-data --rest-listen-addr 127.0.0.1:8002 --cluster-listen-addr 127.0.0.1:8003 --seed 127.0.0.1:8001 --seed 127.0.0.1:8005"
+cargo run --release -- --node-id 3 --data-dir "./my-data/node-3-data --rest-listen-addr 127.0.0.1:8004 --cluster-listen-addr 127.0.0.1:8005 --seed 127.0.0.1:8001 --seed 127.0.0.1:8003"
 ```
 
 This will start a local 3 node cluster, for simplicity we've set the seeds to be each node's peers rather although this does

--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         args.seeds.into_iter(),
     );
 
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new("node-1", connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
         .connect()
         .await?;
     let store = node


### PR DESCRIPTION
This reduces the size of the `HLCTimestamp` to a single `u64` value.

Some new methods are introduced in the form of `from_u64` and `as_u64` which allow you to get a timestamp from a raw u64 value and turn the timestamp into its raw u64 value.