### PR TITLE
Fix typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Datacake provides several utility libraries as well as some pre-made data store 
   storage trait.
 - `datacake-sqlite` - A pre-built and tested implementation of the datacake `Storage` trait built 
   upon SQLite.
-- `datacake-rpc` - A fast, zero-copy RCP framework with a familiar actor-like feel to it.
+- `datacake-rpc` - A fast, zero-copy RPC framework with a familiar actor-like feel to it.
 
 ### Examples
 Check out some pre-built apps we have in the 


### PR DESCRIPTION
`RCP` -> `RPC`