### PR TITLE
Correctly pass the command line node_id arugment

### DIFF
--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -38,8 +38,7 @@ async fn main() -> Result<()> {
         args.seeds.into_iter(),
     );
 
-    let node_id: u8 = args.node_id.parse().unwrap();
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(node_id, connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(args.node_id, connection_cfg)
         .connect()
         .await?;
     let store = node
@@ -67,7 +66,7 @@ async fn main() -> Result<()> {
 pub struct Args {
     #[arg(long)]
     /// The unique ID of the node.
-    node_id: String,
+    node_id: u8,
 
     #[arg(long = "seed")]
     /// The set of seed nodes.

--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -38,7 +38,8 @@ async fn main() -> Result<()> {
         args.seeds.into_iter(),
     );
 
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
+    let node_id: u8 = args.node_id.parse().unwrap();
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(node_id, connection_cfg)
         .connect()
         .await?;
     let store = node


### PR DESCRIPTION
## Overview:

Prior to the fix, trying to start a cluster as described in the readme would fail as each node would effectively initialize as node 1, irrespective of the command line argument.

## Description of changes
Very simple fix that changes a hard coded value of 1 during node creation to using the node_id argument passed by the command line.

## Testing
- Conducted many experiments using the replicated-kv in different cluster configurations

Closes #52 