### PR TITLE
54 expose keyspace list meta iter

### DIFF
--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -335,9 +335,7 @@ where
     }
 
     /// Retrieves the list of keyspaces from the underlying storage.
-    pub async fn get_keyspace_list(
-        &self,
-    ) -> Result<Vec<String>, S::Error> {
+    pub async fn get_keyspace_list(&self) -> Result<Vec<String>, S::Error> {
         let storage = self.group.storage();
         storage.get_keyspace_list().await
     }
@@ -351,7 +349,6 @@ where
         storage.iter_metadata(keyspace).await
     }
 
-    
     /// Retrieves a document from the underlying storage.
     pub async fn get(
         &self,

--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -72,7 +72,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use datacake_crdt::Key;
+use datacake_crdt::{Key, HLCTimestamp};
 use datacake_node::{
     ClusterExtension,
     Consistency,
@@ -341,6 +341,21 @@ where
         let storage = self.group.storage();
         storage.get_keyspace_list().await
     }
+
+    /// Retrieves all keys contained within the store.
+    pub async fn get_keyspace_keys(
+        &self,
+        keyspace: &str,
+    ) -> Result<Vec<(Key, HLCTimestamp, bool)>, S::Error> {
+        let storage = self.group.storage();
+        let res = storage
+            .iter_metadata(keyspace)
+            .await?
+            .collect::<Vec<(Key, HLCTimestamp, bool)>>();
+
+        Ok(res)
+    }
+
     
     /// Retrieves a document from the underlying storage.
     pub async fn get(

--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -72,7 +72,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use datacake_crdt::{Key, HLCTimestamp};
+use datacake_crdt::Key;
 use datacake_node::{
     ClusterExtension,
     Consistency,
@@ -343,17 +343,12 @@ where
     }
 
     /// Retrieves all keys contained within the store.
-    pub async fn get_keyspace_keys(
+    pub async fn iter_metadata(
         &self,
         keyspace: &str,
-    ) -> Result<Vec<(Key, HLCTimestamp, bool)>, S::Error> {
+    ) -> Result<S::MetadataIter, S::Error> {
         let storage = self.group.storage();
-        let res = storage
-            .iter_metadata(keyspace)
-            .await?
-            .collect::<Vec<(Key, HLCTimestamp, bool)>>();
-
-        Ok(res)
+        storage.iter_metadata(keyspace).await
     }
 
     

--- a/datacake-eventual-consistency/src/lib.rs
+++ b/datacake-eventual-consistency/src/lib.rs
@@ -334,6 +334,14 @@ where
         }
     }
 
+    /// Retrieves the list of keyspaces from the underlying storage.
+    pub async fn get_keyspace_list(
+        &self,
+    ) -> Result<Vec<String>, S::Error> {
+        let storage = self.group.storage();
+        storage.get_keyspace_list().await
+    }
+    
     /// Retrieves a document from the underlying storage.
     pub async fn get(
         &self,

--- a/datacake-eventual-consistency/tests/multiple_keyspace.rs
+++ b/datacake-eventual-consistency/tests/multiple_keyspace.rs
@@ -160,7 +160,6 @@ async fn test_multi_node() -> anyhow::Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn test_keyspace_list() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
@@ -205,20 +204,24 @@ async fn test_keyspace_list() -> anyhow::Result<()> {
     let doc = handle.get_keyspace_list().await.unwrap();
     let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string()];
     assert!(doc.iter().all(|item| result.contains(item)));
-    
+
     handle
-    .put(
-        KEYSPACE_3,
-        1,
-        b"Hello, world! From keyspace 3.".to_vec(),
-        Consistency::All,
-    )
-    .await
-    .expect("Put doc.");
+        .put(
+            KEYSPACE_3,
+            1,
+            b"Hello, world! From keyspace 3.".to_vec(),
+            Consistency::All,
+        )
+        .await
+        .expect("Put doc.");
 
     let doc = handle.get_keyspace_list().await.unwrap();
-    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string(), KEYSPACE_3.to_string()];
-    assert!(doc.iter().all(|item| result.contains(item)));    
+    let result = vec![
+        KEYSPACE_1.to_string(),
+        KEYSPACE_2.to_string(),
+        KEYSPACE_3.to_string(),
+    ];
+    assert!(doc.iter().all(|item| result.contains(item)));
 
     Ok(())
 }
@@ -240,34 +243,66 @@ async fn test_iter_metadata() -> anyhow::Result<()> {
 
     let handle = store_1.handle();
 
-    handle.put(KEYSPACE_1,1,b"Hello, world! From keyspace 1. Key 1".to_vec(),Consistency::All,)
+    handle
+        .put(
+            KEYSPACE_1,
+            1,
+            b"Hello, world! From keyspace 1. Key 1".to_vec(),
+            Consistency::All,
+        )
         .await
         .expect("Put doc.");
-    handle.put(KEYSPACE_1,2,b"Hello, world! From keyspace 1. Key 2".to_vec(),Consistency::All,)
+    handle
+        .put(
+            KEYSPACE_1,
+            2,
+            b"Hello, world! From keyspace 1. Key 2".to_vec(),
+            Consistency::All,
+        )
         .await
         .expect("Put doc.");
-    handle.put(KEYSPACE_1,3,b"Hello, world! From keyspace 1. Key 3".to_vec(),Consistency::All,)
+    handle
+        .put(
+            KEYSPACE_1,
+            3,
+            b"Hello, world! From keyspace 1. Key 3".to_vec(),
+            Consistency::All,
+        )
         .await
         .expect("Put doc.");
-    handle.put(KEYSPACE_2,100,b"Hello, world! From keyspace 100. Key 1".to_vec(),Consistency::All,)
+    handle
+        .put(
+            KEYSPACE_2,
+            100,
+            b"Hello, world! From keyspace 2. Key 100".to_vec(),
+            Consistency::All,
+        )
         .await
         .expect("Put doc.");
-    handle.put(KEYSPACE_2,99,b"Hello, world! From keyspace 99. Key 1".to_vec(),Consistency::All,)
+    handle
+        .put(
+            KEYSPACE_2,
+            99,
+            b"Hello, world! From keyspace 2. Key 99".to_vec(),
+            Consistency::All,
+        )
         .await
         .expect("Put doc.");
 
-    let keys: Vec<u64> = handle.iter_metadata(KEYSPACE_1)
+    let keys: Vec<u64> = handle
+        .iter_metadata(KEYSPACE_1)
         .await?
         .map(|entry| entry.0)
         .collect();
-    let result: Vec<u64> = vec![1,2,3];
+    let result: Vec<u64> = vec![1, 2, 3];
     assert!(keys.iter().all(|item| result.contains(item)));
 
-    let keys: Vec<u64> = handle.iter_metadata(KEYSPACE_2)
+    let keys: Vec<u64> = handle
+        .iter_metadata(KEYSPACE_2)
         .await?
         .map(|entry| entry.0)
         .collect();
-    let result: Vec<u64> = vec![100,99];
+    let result: Vec<u64> = vec![100, 99];
     assert!(keys.iter().all(|item| result.contains(item)));
 
     Ok(())

--- a/datacake-eventual-consistency/tests/multiple_keyspace.rs
+++ b/datacake-eventual-consistency/tests/multiple_keyspace.rs
@@ -190,7 +190,7 @@ async fn test_keyspace_list() -> anyhow::Result<()> {
 
     let doc = handle.get_keyspace_list().await.unwrap();
     let result = vec![KEYSPACE_1.to_string()];
-    assert_eq!(doc, result);
+    assert!(doc.iter().all(|item| result.contains(item)));
 
     handle
         .put(
@@ -202,11 +202,10 @@ async fn test_keyspace_list() -> anyhow::Result<()> {
         .await
         .expect("Put doc.");
 
-    let doc = handle.get_keyspace_list().await.unwrap().sort();
-    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string()].sort();
-    assert_eq!(doc, result);
+    let doc = handle.get_keyspace_list().await.unwrap();
+    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string()];
+    assert!(doc.iter().all(|item| result.contains(item)));
     
-
     handle
     .put(
         KEYSPACE_3,
@@ -217,16 +216,15 @@ async fn test_keyspace_list() -> anyhow::Result<()> {
     .await
     .expect("Put doc.");
 
-    let doc = handle.get_keyspace_list().await.unwrap().sort();
-    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string(), KEYSPACE_3.to_string()].sort();
-    assert_eq!(doc, result);
-
+    let doc = handle.get_keyspace_list().await.unwrap();
+    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string(), KEYSPACE_3.to_string()];
+    assert!(doc.iter().all(|item| result.contains(item)));    
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_keyspace_keys() -> anyhow::Result<()> {
+async fn test_iter_metadata() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
     let node_addr = test_helper::get_unused_addr();
@@ -251,19 +249,26 @@ async fn test_keyspace_keys() -> anyhow::Result<()> {
     handle.put(KEYSPACE_1,3,b"Hello, world! From keyspace 1. Key 3".to_vec(),Consistency::All,)
         .await
         .expect("Put doc.");
-    handle.put(KEYSPACE_2,1,b"Hello, world! From keyspace 1. Key 1".to_vec(),Consistency::All,)
-    .await
-    .expect("Put doc.");
+    handle.put(KEYSPACE_2,100,b"Hello, world! From keyspace 100. Key 1".to_vec(),Consistency::All,)
+        .await
+        .expect("Put doc.");
+    handle.put(KEYSPACE_2,99,b"Hello, world! From keyspace 99. Key 1".to_vec(),Consistency::All,)
+        .await
+        .expect("Put doc.");
 
-    let doc = handle.get_keyspace_keys(KEYSPACE_1).await.unwrap();
-    let mut keys: Vec<u64> = doc.iter().map(|entry| entry.0).collect();
-    let mut result: Vec<u64> = vec![1,2,3];
-    assert_eq!(keys.sort(), result.sort());
+    let keys: Vec<u64> = handle.iter_metadata(KEYSPACE_1)
+        .await?
+        .map(|entry| entry.0)
+        .collect();
+    let result: Vec<u64> = vec![1,2,3];
+    assert!(keys.iter().all(|item| result.contains(item)));
 
-    let doc = handle.get_keyspace_keys(KEYSPACE_2).await.unwrap();
-    let mut keys: Vec<u64> = doc.iter().map(|entry| entry.0).collect();
-    let mut result: Vec<u64> = vec![1];
-    assert_eq!(keys.sort(), result.sort());
+    let keys: Vec<u64> = handle.iter_metadata(KEYSPACE_2)
+        .await?
+        .map(|entry| entry.0)
+        .collect();
+    let result: Vec<u64> = vec![100,99];
+    assert!(keys.iter().all(|item| result.contains(item)));
 
     Ok(())
 }

--- a/datacake-eventual-consistency/tests/multiple_keyspace.rs
+++ b/datacake-eventual-consistency/tests/multiple_keyspace.rs
@@ -159,3 +159,68 @@ async fn test_multi_node() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+
+#[tokio::test]
+async fn test_keyspace_list() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let node_addr = test_helper::get_unused_addr();
+    let connection_cfg =
+        ConnectionConfig::new(node_addr, node_addr, Vec::<String>::new());
+
+    let node_1 = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
+        .connect()
+        .await?;
+    let store_1 = node_1
+        .add_extension(EventuallyConsistentStoreExtension::new(MemStore::default()))
+        .await?;
+
+    let handle = store_1.handle();
+
+    handle
+        .put(
+            KEYSPACE_1,
+            1,
+            b"Hello, world! From keyspace 1.".to_vec(),
+            Consistency::All,
+        )
+        .await
+        .expect("Put doc.");
+
+    let doc = handle.get_keyspace_list().await.unwrap();
+    let result = vec![KEYSPACE_1.to_string()];
+    assert_eq!(doc, result);
+
+    handle
+        .put(
+            KEYSPACE_2,
+            1,
+            b"Hello, world! From keyspace 2.".to_vec(),
+            Consistency::All,
+        )
+        .await
+        .expect("Put doc.");
+
+    let doc = handle.get_keyspace_list().await.unwrap().sort();
+    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string()].sort();
+    assert_eq!(doc, result);
+    
+
+    handle
+    .put(
+        KEYSPACE_3,
+        1,
+        b"Hello, world! From keyspace 3.".to_vec(),
+        Consistency::All,
+    )
+    .await
+    .expect("Put doc.");
+
+    let doc = handle.get_keyspace_list().await.unwrap().sort();
+    let result = vec![KEYSPACE_1.to_string(), KEYSPACE_2.to_string(), KEYSPACE_3.to_string()].sort();
+    assert_eq!(doc, result);
+
+
+    Ok(())
+}

--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -38,8 +38,7 @@ async fn main() -> Result<()> {
         args.seeds.into_iter(),
     );
 
-    let node_id: u8 = args.node_id.parse().unwrap();
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(node_id, connection_cfg)
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(args.node_id, connection_cfg)
         .connect()
         .await?;
     let store = node
@@ -67,7 +66,7 @@ async fn main() -> Result<()> {
 pub struct Args {
     #[arg(long)]
     /// The unique ID of the node.
-    node_id: String,
+    node_id: u8,
 
     #[arg(long = "seed")]
     /// The set of seed nodes.

--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -38,7 +38,8 @@ async fn main() -> Result<()> {
         args.seeds.into_iter(),
     );
 
-    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(1, connection_cfg)
+    let node_id: u8 = args.node_id.parse().unwrap();
+    let node = DatacakeNodeBuilder::<DCAwareSelector>::new(node_id, connection_cfg)
         .connect()
         .await?;
     let store = node


### PR DESCRIPTION
In writing an application that uses the `datacake_eventual_consistency` it is essential to be able to obtain a list of keyspaces and keys within a keyspace.

Two new functions:

`get_keyspace_list` - returns a vectors of strings listing all keyspaces in the `datacake_eventual_consistency` store.  This effectively just exposes the underlying stores implementation.

`get_keyspace_keys` - rather than returning an iterator to the stores metadata to the, this function collects the keys and returns them as a vector of tuples.

The new functions have associated tests.

Closes #54 