### PR TITLE
Move `rkyv` RPC support to use CRC32 checksums rather than checkbytes and use stack allocated scratch.

### DIFF
--- a/datacake-rpc/Cargo.toml
+++ b/datacake-rpc/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1.37"
 crc32fast = "1.3.2"
 
 hyper = { version = "0.14.23", features = ["full"] }
-rkyv = { version = "0.7.42", features = ["strict", "validation"] }
+rkyv = { version = "0.7.42", features = ["strict"] }
 tokio = { version = "1", default-features = false, features = ["rt"] }
 
 # Used for simulation
@@ -32,6 +32,7 @@ async-stream = { version = "0.3.3", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 test-helper = { path = "../test-helper" }
+rkyv = { version = "0.7.42", features = ["strict", "validation"] }
 
 [features]
 test-utils = []

--- a/datacake-rpc/Cargo.toml
+++ b/datacake-rpc/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1.60"
 thiserror = "1"
 parking_lot = "0.12.1"
 tracing = "0.1.37"
+crc32fast = "1.3.2"
 
 hyper = { version = "0.14.23", features = ["full"] }
 rkyv = { version = "0.7.42", features = ["strict", "validation"] }

--- a/datacake-rpc/src/client.rs
+++ b/datacake-rpc/src/client.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -140,8 +139,8 @@ where
         <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
     {
         let metadata = MessageMetadata {
-            service_name: Cow::Borrowed(<Svc as RpcService>::service_name()),
-            path: Cow::Borrowed(<Svc as Handler<Msg>>::path()),
+            service_name: <Svc as RpcService>::service_name(),
+            path: <Svc as Handler<Msg>>::path(),
         };
 
         let body = msg.try_as_body()?;
@@ -164,8 +163,8 @@ where
         <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
     {
         let metadata = MessageMetadata {
-            service_name: Cow::Borrowed(<Svc as RpcService>::service_name()),
-            path: Cow::Borrowed(<Svc as Handler<Msg>>::path()),
+            service_name: <Svc as RpcService>::service_name(),
+            path: <Svc as Handler<Msg>>::path(),
         };
 
         let body = msg.try_into_body()?;

--- a/datacake-rpc/src/client.rs
+++ b/datacake-rpc/src/client.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::handler::{Handler, RpcService, TryAsBody, TryIntoBody};
 use crate::net::{Channel, Status};
 use crate::request::{MessageMetadata, RequestContents};
-use crate::Body;
+use crate::{Body, DataView};
 
 /// A type alias for the returned data view of the RPC message reply.
 pub type MessageReply<Svc, Msg> =
@@ -197,8 +197,9 @@ where
         match result {
             Ok(body) => <<Svc as Handler<Msg>>::Reply>::from_body(body).await,
             Err(buffer) => {
-                let status = rkyv::from_bytes(&buffer).map_err(|_| Status::invalid())?;
-                Err(status)
+                let status =
+                    DataView::<Status>::using(buffer).map_err(|_| Status::invalid())?;
+                Err(status.to_owned().unwrap_or_else(|_| Status::invalid()))
             },
         }
     }

--- a/datacake-rpc/src/lib.rs
+++ b/datacake-rpc/src/lib.rs
@@ -104,8 +104,6 @@ mod rkyv_tooling;
 mod server;
 mod utils;
 
-pub(crate) const SCRATCH_SPACE: usize = 4096;
-
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 

--- a/datacake-rpc/src/lib.rs
+++ b/datacake-rpc/src/lib.rs
@@ -100,9 +100,9 @@ mod client;
 mod handler;
 mod net;
 mod request;
+mod rkyv_tooling;
 mod server;
 mod utils;
-mod view;
 
 pub(crate) const SCRATCH_SPACE: usize = 4096;
 
@@ -111,13 +111,21 @@ use std::hash::{Hash, Hasher};
 
 /// A re-export of the async-trait macro.
 pub use async_trait::async_trait;
-pub use body::Body;
-pub use client::{MessageReply, RpcClient};
-pub use handler::{Handler, RpcService, ServiceRegistry, TryAsBody, TryIntoBody};
-pub use net::{ArchivedErrorCode, ArchivedStatus, Channel, Error, ErrorCode, Status};
-pub use request::{Request, RequestContents};
-pub use server::Server;
-pub use view::{DataView, InvalidView};
+
+pub use self::body::Body;
+pub use self::client::{MessageReply, RpcClient};
+pub use self::handler::{Handler, RpcService, ServiceRegistry, TryAsBody, TryIntoBody};
+pub use self::net::{
+    ArchivedErrorCode,
+    ArchivedStatus,
+    Channel,
+    Error,
+    ErrorCode,
+    Status,
+};
+pub use self::request::{Request, RequestContents};
+pub use self::rkyv_tooling::{DataView, InvalidView};
+pub use self::server::Server;
 
 pub(crate) fn hash<H: Hash + ?Sized>(v: &H) -> u64 {
     let mut hasher = DefaultHasher::new();

--- a/datacake-rpc/src/net/client.rs
+++ b/datacake-rpc/src/net/client.rs
@@ -61,11 +61,7 @@ impl Channel {
         metadata: MessageMetadata,
         msg: Body,
     ) -> Result<Result<Body, AlignedVec>, Error> {
-        let uri = format!(
-            "http://{}{}",
-            self.remote_addr,
-            crate::to_uri_path(&metadata.service_name, &metadata.path),
-        );
+        let uri = format!("http://{}{}", self.remote_addr, metadata.to_uri_path(),);
         let request = Request::builder()
             .method(Method::POST)
             .uri(uri)

--- a/datacake-rpc/src/rkyv_tooling/mod.rs
+++ b/datacake-rpc/src/rkyv_tooling/mod.rs
@@ -1,0 +1,119 @@
+use rkyv::ser::serializers::{
+    AlignedSerializer,
+    CompositeSerializer,
+    SharedSerializeMap,
+};
+use rkyv::ser::Serializer;
+use rkyv::{AlignedVec, Fallible, Serialize};
+
+mod scratch;
+mod view;
+
+use self::scratch::LazyScratch;
+pub use self::view::{DataView, InvalidView};
+
+pub(crate) type DatacakeSerializer =
+    CompositeSerializer<AlignedSerializer<AlignedVec>, LazyScratch, SharedSerializeMap>;
+
+#[inline]
+/// Produces an aligned buffer of the serialized data with a CRC32 checksum attached
+/// to the last 4 bytes of the buffer.
+pub fn to_view_bytes<T>(
+    value: &T,
+) -> Result<AlignedVec, <DatacakeSerializer as Fallible>::Error>
+where
+    T: Serialize<DatacakeSerializer>,
+{
+    let mut serializer = DatacakeSerializer::new(
+        AlignedSerializer::new(AlignedVec::with_capacity(512)),
+        LazyScratch::default(),
+        SharedSerializeMap::new(),
+    );
+
+    serializer.serialize_value(value)?;
+
+    let serializer = serializer.into_serializer();
+    let mut buffer = serializer.into_inner();
+
+    let checksum = crc32fast::hash(&buffer);
+    buffer.extend_from_slice(&checksum.to_le_bytes());
+
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rkyv::{Archive, Serialize};
+
+    use super::*;
+
+    #[derive(Archive, Serialize)]
+    #[archive(check_bytes)]
+    struct FixedSize {
+        a: u32,
+        b: f64,
+        c: i64,
+        buf: [u8; 12],
+    }
+
+    #[derive(Archive, Serialize)]
+    #[archive(check_bytes)]
+    struct AllocatedSize {
+        a: u32,
+        b: f64,
+        c: HashMap<String, u64>,
+        buf: Vec<u8>,
+    }
+
+    #[test]
+    fn test_static_size_serialize() {
+        let val = FixedSize {
+            a: 123,
+            b: 1.23,
+            c: -123,
+            buf: Default::default(),
+        };
+
+        let buffer = to_view_bytes(&val).expect("Serialize struct");
+
+        let end = buffer.len();
+
+        rkyv::check_archived_root::<FixedSize>(&buffer[..end - 4])
+            .expect("Get archived value");
+
+        let checksum_bytes = buffer[end - 4..].try_into().unwrap();
+        let expected_checksum = u32::from_le_bytes(checksum_bytes);
+        let actual_checksum = crc32fast::hash(&buffer[..end - 4]);
+
+        assert_eq!(expected_checksum, actual_checksum, "Checksums should match");
+    }
+
+    #[test]
+    fn test_heap_size_serialize() {
+        let val = AllocatedSize {
+            a: 123,
+            b: 1.23,
+            c: {
+                let mut map = HashMap::new();
+                map.insert("hello".to_string(), 3);
+                map
+            },
+            buf: vec![4; 10],
+        };
+
+        let buffer = to_view_bytes(&val).expect("Serialize struct");
+
+        let end = buffer.len();
+
+        rkyv::check_archived_root::<FixedSize>(&buffer[..end - 4])
+            .expect("Get archived value");
+
+        let checksum_bytes = buffer[end - 4..].try_into().unwrap();
+        let expected_checksum = u32::from_le_bytes(checksum_bytes);
+        let actual_checksum = crc32fast::hash(&buffer[..end - 4]);
+
+        assert_eq!(expected_checksum, actual_checksum, "Checksums should match");
+    }
+}

--- a/datacake-rpc/src/rkyv_tooling/scratch.rs
+++ b/datacake-rpc/src/rkyv_tooling/scratch.rs
@@ -1,0 +1,110 @@
+use std::alloc::Layout;
+use std::ptr::NonNull;
+
+use rkyv::ser::serializers::{AllocScratch, BufferScratch, HeapScratch};
+use rkyv::ser::ScratchSpace;
+use rkyv::{AlignedBytes, Fallible};
+
+const STACK_SCRATCH_SIZE: usize = 1024;
+const HEAP_SCRATCH_SIZE: usize = 16 << 10;
+
+#[derive(Debug)]
+/// Allocates scratch space with a stack, fallback heap scratch, and then an alloc scratch.
+///
+/// The fallback heap scratch is lazily allocated.
+pub struct LazyScratch {
+    stack_scratch: StackScratch,
+    heap_scratch: Option<HeapScratch<HEAP_SCRATCH_SIZE>>,
+    alloc_scratch: AllocScratch,
+}
+
+impl Default for LazyScratch {
+    fn default() -> Self {
+        Self {
+            stack_scratch: StackScratch::default(),
+            heap_scratch: None,
+            alloc_scratch: AllocScratch::default(),
+        }
+    }
+}
+
+impl Fallible for LazyScratch {
+    type Error = <AllocScratch as Fallible>::Error;
+}
+
+impl ScratchSpace for LazyScratch {
+    #[inline]
+    unsafe fn push_scratch(
+        &mut self,
+        layout: Layout,
+    ) -> Result<NonNull<[u8]>, Self::Error> {
+        if let Ok(buf) = self.stack_scratch.push_scratch(layout) {
+            return Ok(buf);
+        }
+
+        let heap_scratch = self.heap_scratch.get_or_insert_with(HeapScratch::new);
+
+        if let Ok(buf) = heap_scratch.push_scratch(layout) {
+            return Ok(buf);
+        }
+
+        self.alloc_scratch.push_scratch(layout)
+    }
+
+    #[inline]
+    unsafe fn pop_scratch(
+        &mut self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+    ) -> Result<(), Self::Error> {
+        if self.stack_scratch.pop_scratch(ptr, layout).is_ok() {
+            return Ok(());
+        }
+
+        let heap_scratch = self.heap_scratch.get_or_insert_with(HeapScratch::new);
+
+        if heap_scratch.pop_scratch(ptr, layout).is_ok() {
+            return Ok(());
+        }
+
+        self.alloc_scratch.pop_scratch(ptr, layout)
+    }
+}
+
+#[derive(Debug)]
+/// A stack allocated scratch space.
+struct StackScratch {
+    inner: BufferScratch<AlignedBytes<STACK_SCRATCH_SIZE>>,
+}
+
+impl Default for StackScratch {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            inner: BufferScratch::new(AlignedBytes::default()),
+        }
+    }
+}
+
+impl Fallible for StackScratch {
+    type Error = <BufferScratch<AlignedBytes<STACK_SCRATCH_SIZE>> as Fallible>::Error;
+}
+
+impl ScratchSpace for StackScratch {
+    #[inline]
+    unsafe fn push_scratch(
+        &mut self,
+        layout: Layout,
+    ) -> Result<NonNull<[u8]>, Self::Error> {
+        self.inner.push_scratch(layout)
+    }
+
+    #[inline]
+    unsafe fn pop_scratch(
+        &mut self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+    ) -> Result<(), Self::Error> {
+        self.inner.pop_scratch(ptr, layout)
+    }
+}

--- a/datacake-rpc/src/rkyv_tooling/view.rs
+++ b/datacake-rpc/src/rkyv_tooling/view.rs
@@ -64,11 +64,13 @@ where
         Ok(Self { data, view })
     }
 
+    #[inline]
     /// Gets the bytes representation of the dataview.
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
     }
 
+    #[inline]
     /// Consumes the bytes representation of the dataview.
     pub fn into_data(self) -> AlignedVec {
         self.data
@@ -80,6 +82,7 @@ where
     T: Archive,
     T::Archived: Deserialize<T, SharedDeserializeMap> + 'static,
 {
+    #[inline]
     /// Deserializes the view into it's owned value T.
     pub fn to_owned(&self) -> Result<T, InvalidView> {
         self.view

--- a/datacake-rpc/tests/stream.rs
+++ b/datacake-rpc/tests/stream.rs
@@ -34,8 +34,8 @@ impl Handler<MyMessage> for MyService {
     type Reply = Body;
 
     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-        let bytes = msg.into_inner().into_data();
-        Ok(Body::from(bytes.to_vec()))
+        let bytes = msg.buffer.as_ref().to_vec();
+        Ok(Body::from(bytes))
     }
 }
 
@@ -58,10 +58,9 @@ async fn test_stream_body() {
         buffer: vec![0u8; 32 << 10],
     };
 
-    let bytes = rkyv::to_bytes::<_, 1024>(&msg1).unwrap();
     let resp = rpc_client.send(&msg1).await.unwrap();
     let body = hyper::body::to_bytes(resp.into_inner()).await.unwrap();
-    assert_eq!(bytes.as_ref(), body.as_ref());
+    assert_eq!(msg1.buffer, body.as_ref());
 
     server.shutdown();
 }


### PR DESCRIPTION
This should improve the performance on smaller message payloads by cutting out lots of small allocations on the serializer side when messages require less than 1KB of scratch space.

- We also move to checksum-based validation to ensure better data integrity not just layout and alignment.
- `DataView` has also had its `D` (data holder) generic removed as it is completely unnecessary. 
- This allows users to use the RPC system without needing check bytes.