### PR TITLE
Add the ability to recieve and send headers on requests.

### DIFF
--- a/datacake-rpc/src/body.rs
+++ b/datacake-rpc/src/body.rs
@@ -1,9 +1,15 @@
 use std::ops::{Deref, DerefMut};
 
+use rkyv::{Archive, Serialize};
+
+use crate::rkyv_tooling::DatacakeSerializer;
+use crate::Status;
+
 /// A wrapper type around the internal [hyper::Body]
 pub struct Body(pub(crate) hyper::Body);
 
 impl Body {
+    /// Creates a new body.
     pub fn new(inner: hyper::Body) -> Self {
         Self(inner)
     }
@@ -34,5 +40,57 @@ impl Deref for Body {
 impl DerefMut for Body {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+/// The serializer trait converting replies into hyper bodies.
+///
+/// This is a light abstraction to allow users to be able to
+/// stream data across the RPC system which may not fit in memory.
+///
+/// Any types which implement [TryAsBody] will implement this type.
+pub trait TryIntoBody {
+    /// Try convert the reply into a body or return an error
+    /// status.
+    fn try_into_body(self) -> Result<Body, Status>;
+}
+
+/// The serializer trait for converting replies into hyper bodies
+/// using a reference to self.
+///
+/// This will work for most implementations but if you want to stream
+/// hyper bodies for example, you cannot implement this trait.
+pub trait TryAsBody {
+    /// Try convert the reply into a body or return an error
+    /// status.
+    fn try_as_body(&self) -> Result<Body, Status>;
+}
+
+impl<T> TryAsBody for T
+where
+    T: Archive + Serialize<DatacakeSerializer>,
+{
+    #[inline]
+    fn try_as_body(&self) -> Result<Body, Status> {
+        crate::rkyv_tooling::to_view_bytes(self)
+            .map(|v| Body::from(v.to_vec()))
+            .map_err(|e| Status::internal(e.to_string()))
+    }
+}
+
+impl<T> TryIntoBody for T
+where
+    T: TryAsBody,
+{
+    #[inline]
+    fn try_into_body(self) -> Result<Body, Status> {
+        <Self as TryAsBody>::try_as_body(&self)
+    }
+}
+
+impl TryIntoBody for Body {
+    #[inline]
+    fn try_into_body(self) -> Result<Body, Status> {
+        Ok(self)
     }
 }

--- a/datacake-rpc/src/client.rs
+++ b/datacake-rpc/src/client.rs
@@ -1,5 +1,9 @@
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::time::Duration;
+
+use http::header::IntoHeaderName;
+use http::{HeaderMap, HeaderValue, StatusCode};
 
 use crate::handler::{Handler, RpcService, TryAsBody, TryIntoBody};
 use crate::net::{Channel, Status};
@@ -108,6 +112,7 @@ where
         self.timeout = Some(timeout);
     }
 
+    #[inline]
     /// Creates a new RPC client which can handle a new service type.
     ///
     /// [RpcClient]'s are cheap to create and should be preferred over
@@ -123,6 +128,7 @@ where
         }
     }
 
+    #[inline]
     /// Sends a message to the server and wait for a reply.
     ///
     /// This lets you send messages behind a reference which can help
@@ -138,15 +144,11 @@ where
         // this on the trait side, which is a shame.
         <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
     {
-        let metadata = MessageMetadata {
-            service_name: <Svc as RpcService>::service_name(),
-            path: <Svc as Handler<Msg>>::path(),
-        };
-
-        let body = msg.try_as_body()?;
-        self.send_body(body, metadata).await
+        let ctx = self.create_rpc_context();
+        ctx.send(msg).await.map(|r| r.into_inner())
     }
 
+    #[inline]
     /// Sends a message to the server and wait for a reply using an owned
     /// message value.
     ///
@@ -162,20 +164,116 @@ where
         // this on the trait side, which is a shame.
         <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
     {
+        let ctx = self.create_rpc_context();
+        ctx.send_owned(msg).await.map(|r| r.into_inner())
+    }
+
+    #[inline]
+    /// Creates a new RPC context which can customise more of
+    /// the request than the convenience methods, i.e. Headers.
+    pub fn create_rpc_context(&self) -> RpcContext<Svc> {
+        RpcContext {
+            client: self,
+            headers: HeaderMap::new(),
+        }
+    }
+}
+
+/// A configurable RPC context that can be used to
+/// fine tune the request/response of the RPC calls.
+///
+/// This allows you to pass and receive headers while
+/// being reasonably convenient and without
+/// breaking existing implementations.
+pub struct RpcContext<'a, Svc>
+where
+    Svc: RpcService,
+{
+    client: &'a RpcClient<Svc>,
+    headers: HeaderMap,
+}
+
+impl<'a, Svc> RpcContext<'a, Svc>
+where
+    Svc: RpcService,
+{
+    /// Set a single request header.
+    pub fn set_header<K>(mut self, key: K, value: HeaderValue) -> Self
+    where
+        K: IntoHeaderName,
+    {
+        self.headers.insert(key, value);
+        self
+    }
+
+    /// Set multiple request headers.
+    pub fn set_headers<K, I>(mut self, headers: I) -> Self
+    where
+        K: IntoHeaderName,
+        I: IntoIterator<Item = (K, HeaderValue)>,
+    {
+        for (key, value) in headers {
+            self.headers.insert(key, value);
+        }
+        self
+    }
+
+    /// Sends a message to the server and wait for a reply.
+    ///
+    /// This lets you send messages behind a reference which can help
+    /// avoid excess copies when it isn't needed.
+    ///
+    /// In the event you need to send a [Body] or type which must consume `self`
+    /// you can use [Self::send_owned]
+    pub async fn send<Msg>(
+        self,
+        msg: &Msg,
+    ) -> Result<Response<MessageReply<Svc, Msg>>, Status>
+    where
+        Msg: RequestContents + TryAsBody,
+        Svc: Handler<Msg>,
+        // Due to some interesting compiler errors, we couldn't use GATs here to enforce
+        // this on the trait side, which is a shame.
+        <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
+    {
+        let metadata = MessageMetadata {
+            service_name: <Svc as RpcService>::service_name(),
+            path: <Svc as Handler<Msg>>::path(),
+        };
+
+        let body = msg.try_as_body()?;
+        self.send_inner(body, metadata).await
+    }
+
+    /// Sends a message to the server and wait for a reply using an owned
+    /// message value.
+    ///
+    /// This allows you to send types implementing [TryIntoBody] like [Body].
+    pub async fn send_owned<Msg>(
+        self,
+        msg: Msg,
+    ) -> Result<Response<MessageReply<Svc, Msg>>, Status>
+    where
+        Msg: RequestContents + TryIntoBody,
+        Svc: Handler<Msg>,
+        // Due to some interesting compiler errors, we couldn't use GATs here to enforce
+        // this on the trait side, which is a shame.
+        <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
+    {
         let metadata = MessageMetadata {
             service_name: <Svc as RpcService>::service_name(),
             path: <Svc as Handler<Msg>>::path(),
         };
 
         let body = msg.try_into_body()?;
-        self.send_body(body, metadata).await
+        self.send_inner(body, metadata).await
     }
 
-    async fn send_body<Msg>(
-        &self,
+    async fn send_inner<Msg>(
+        self,
         body: Body,
         metadata: MessageMetadata,
-    ) -> Result<MessageReply<Svc, Msg>, Status>
+    ) -> Result<Response<MessageReply<Svc, Msg>>, Status>
     where
         Msg: RequestContents,
         Svc: Handler<Msg>,
@@ -183,9 +281,9 @@ where
         // this on the trait side, which is a shame.
         <Svc as Handler<Msg>>::Reply: RequestContents + TryIntoBody,
     {
-        let future = self.channel.send_msg(metadata, body);
+        let future = self.client.channel.send_parts(metadata, self.headers, body);
 
-        let result = match self.timeout {
+        let response = match self.client.timeout {
             Some(duration) => tokio::time::timeout(duration, future)
                 .await
                 .map_err(|_| Status::timeout())?
@@ -193,13 +291,59 @@ where
             None => future.await.map_err(Status::connection)?,
         };
 
-        match result {
-            Ok(body) => <<Svc as Handler<Msg>>::Reply>::from_body(body).await,
-            Err(buffer) => {
-                let status =
-                    DataView::<Status>::using(buffer).map_err(|_| Status::invalid())?;
-                Err(status.to_owned().unwrap_or_else(|_| Status::invalid()))
-            },
+        let (head, body) = response.into_parts();
+
+        if head.status == StatusCode::OK {
+            let msg = <<Svc as Handler<Msg>>::Reply>::from_body(Body::new(body)).await?;
+            return Ok(Response::new(head.headers, msg));
         }
+
+        let buffer = crate::utils::to_aligned(body)
+            .await
+            .map_err(|e| Status::internal(e.message()))?;
+        let status = DataView::<Status>::using(buffer).map_err(|_| Status::invalid())?;
+        Err(status.to_owned().unwrap_or_else(|_| Status::invalid()))
+    }
+}
+
+/// A verbose RPC response.
+///
+/// This contains the inner message type `Msg` and the response headers
+/// returned by the server.
+pub struct Response<Msg> {
+    headers: HeaderMap,
+    inner: Msg,
+}
+
+impl<Msg> Response<Msg> {
+    /// Creates a new response type.
+    fn new(headers: HeaderMap, inner: Msg) -> Self {
+        Self { headers, inner }
+    }
+
+    #[inline]
+    /// Consumes the response returning the inner message.
+    pub fn into_inner(self) -> Msg {
+        self.inner
+    }
+
+    #[inline]
+    /// Consumes the response returning the headers and inner message.
+    pub fn into_parts(self) -> (HeaderMap, Msg) {
+        (self.headers, self.inner)
+    }
+
+    #[inline]
+    /// The request headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+
+impl<Msg> Deref for Response<Msg> {
+    type Target = Msg;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/datacake-rpc/src/handler.rs
+++ b/datacake-rpc/src/handler.rs
@@ -5,11 +5,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::HeaderMap;
-use rkyv::{Archive, Serialize};
 
+use crate::body::TryIntoBody;
 use crate::net::Status;
 use crate::request::{Request, RequestContents};
-use crate::rkyv_tooling::DatacakeSerializer;
 use crate::Body;
 
 /// A specific handler key.
@@ -270,57 +269,5 @@ where
             .on_message(msg)
             .await
             .and_then(|reply| reply.try_into_body())
-    }
-}
-
-/// The serializer trait converting replies into hyper bodies.
-///
-/// This is a light abstraction to allow users to be able to
-/// stream data across the RPC system which may not fit in memory.
-///
-/// Any types which implement [TryAsBody] will implement this type.
-pub trait TryIntoBody {
-    /// Try convert the reply into a body or return an error
-    /// status.
-    fn try_into_body(self) -> Result<Body, Status>;
-}
-
-/// The serializer trait for converting replies into hyper bodies
-/// using a reference to self.
-///
-/// This will work for most implementations but if you want to stream
-/// hyper bodies for example, you cannot implement this trait.
-pub trait TryAsBody {
-    /// Try convert the reply into a body or return an error
-    /// status.
-    fn try_as_body(&self) -> Result<Body, Status>;
-}
-
-impl<T> TryAsBody for T
-where
-    T: Archive + Serialize<DatacakeSerializer>,
-{
-    #[inline]
-    fn try_as_body(&self) -> Result<Body, Status> {
-        crate::rkyv_tooling::to_view_bytes(self)
-            .map(|v| Body::from(v.to_vec()))
-            .map_err(|e| Status::internal(e.to_string()))
-    }
-}
-
-impl<T> TryIntoBody for T
-where
-    T: TryAsBody,
-{
-    #[inline]
-    fn try_into_body(self) -> Result<Body, Status> {
-        <Self as TryAsBody>::try_as_body(&self)
-    }
-}
-
-impl TryIntoBody for Body {
-    #[inline]
-    fn try_into_body(self) -> Result<Body, Status> {
-        Ok(self)
     }
 }

--- a/datacake-rpc/src/handler.rs
+++ b/datacake-rpc/src/handler.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use http::HeaderMap;
 use rkyv::{Archive, Serialize};
 
 use crate::net::Status;
@@ -235,7 +236,8 @@ pub(crate) trait OpaqueMessageHandler: Send + Sync {
     async fn try_handle(
         &self,
         remote_addr: SocketAddr,
-        data: Body,
+        headers: HeaderMap,
+        body: Body,
     ) -> Result<Body, Status>;
 }
 
@@ -257,11 +259,12 @@ where
     async fn try_handle(
         &self,
         remote_addr: SocketAddr,
-        data: Body,
+        headers: HeaderMap,
+        body: Body,
     ) -> Result<Body, Status> {
-        let view = Msg::from_body(data).await?;
+        let view = Msg::from_body(body).await?;
 
-        let msg = Request::new(remote_addr, view);
+        let msg = Request::new(remote_addr, headers, view);
 
         self.handler
             .on_message(msg)

--- a/datacake-rpc/src/lib.rs
+++ b/datacake-rpc/src/lib.rs
@@ -109,10 +109,11 @@ use std::hash::{Hash, Hasher};
 
 /// A re-export of the async-trait macro.
 pub use async_trait::async_trait;
+pub use http;
 
-pub use self::body::Body;
+pub use self::body::{Body, TryAsBody, TryIntoBody};
 pub use self::client::{MessageReply, RpcClient};
-pub use self::handler::{Handler, RpcService, ServiceRegistry, TryAsBody, TryIntoBody};
+pub use self::handler::{Handler, RpcService, ServiceRegistry};
 pub use self::net::{
     ArchivedErrorCode,
     ArchivedStatus,

--- a/datacake-rpc/src/net/server.rs
+++ b/datacake-rpc/src/net/server.rs
@@ -107,12 +107,15 @@ async fn try_handle_request(
 ) -> Result<Body, Status> {
     let (req, body) = req.into_parts();
     let uri = req.uri.path();
+    let headers = req.headers;
 
     let handler = state
         .get_handler(uri)
         .ok_or_else(|| Status::unavailable(format!("Unknown service {uri}")))?;
 
-    handler.try_handle(remote_addr, Body::new(body)).await
+    handler
+        .try_handle(remote_addr, headers, Body::new(body))
+        .await
 }
 
 fn create_bad_request(status: &Status) -> Response<hyper::Body> {

--- a/datacake-rpc/src/rkyv_tooling/view.rs
+++ b/datacake-rpc/src/rkyv_tooling/view.rs
@@ -42,7 +42,7 @@ where
         let extended_buf =
             unsafe { mem::transmute::<&[u8], &'static [u8]>(data.as_slice()) };
 
-        if extended_buf.len() <= 4 {
+        if extended_buf.len() < 4 {
             return Err(InvalidView);
         }
 

--- a/datacake-rpc/tests/passing_headers.rs
+++ b/datacake-rpc/tests/passing_headers.rs
@@ -1,0 +1,132 @@
+use std::collections::BTreeMap;
+
+use datacake_rpc::{
+    Channel,
+    Handler,
+    Request,
+    RpcClient,
+    RpcService,
+    Server,
+    ServiceRegistry,
+    Status,
+};
+use http::HeaderValue;
+use rkyv::{Archive, Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Archive, Debug)]
+#[archive_attr(derive(Debug))]
+pub struct SingleHeader;
+
+#[derive(Serialize, Deserialize, Archive, Debug)]
+#[archive_attr(derive(Debug))]
+pub struct ManyHeaders;
+
+pub struct MyService;
+
+impl RpcService for MyService {
+    fn register_handlers(registry: &mut ServiceRegistry<Self>) {
+        registry.add_handler::<SingleHeader>();
+        registry.add_handler::<ManyHeaders>();
+    }
+}
+
+#[datacake_rpc::async_trait]
+impl Handler<SingleHeader> for MyService {
+    type Reply = Option<String>;
+
+    async fn on_message(
+        &self,
+        msg: Request<SingleHeader>,
+    ) -> Result<Self::Reply, Status> {
+        let header = msg
+            .headers()
+            .get("hello")
+            .map(|h| h.to_str().unwrap().to_string());
+
+        Ok(header)
+    }
+}
+
+#[datacake_rpc::async_trait]
+impl Handler<ManyHeaders> for MyService {
+    type Reply = BTreeMap<String, String>;
+
+    async fn on_message(
+        &self,
+        msg: Request<ManyHeaders>,
+    ) -> Result<Self::Reply, Status> {
+        let mut headers = BTreeMap::new();
+
+        for (key, value) in msg.headers() {
+            let value = value.to_str().unwrap().to_string();
+
+            headers.insert(key.to_string(), value);
+        }
+
+        Ok(headers)
+    }
+}
+
+#[tokio::test]
+async fn test_sending_headers() {
+    let addr = test_helper::get_unused_addr();
+
+    let server = Server::listen(addr).await.unwrap();
+    server.add_service(MyService);
+    println!("Listening to address {}!", addr);
+
+    let client = Channel::connect(addr);
+    println!("Connected to address {}!", addr);
+
+    let rpc_client = RpcClient::<MyService>::new(client);
+
+    let response = rpc_client
+        .create_rpc_context()
+        .set_header("hello", HeaderValue::from_static("world"))
+        .send(&SingleHeader)
+        .await
+        .expect("Send RPC message");
+
+    assert_eq!(
+        response,
+        Some("world".to_string()),
+        "Header should be received"
+    );
+
+    server.shutdown();
+}
+
+#[tokio::test]
+async fn test_sending_many_headers() {
+    let addr = test_helper::get_unused_addr();
+
+    let server = Server::listen(addr).await.unwrap();
+    server.add_service(MyService);
+    println!("Listening to address {}!", addr);
+
+    let client = Channel::connect(addr);
+    println!("Connected to address {}!", addr);
+
+    let rpc_client = RpcClient::<MyService>::new(client);
+
+    let response = rpc_client
+        .create_rpc_context()
+        .set_headers([
+            ("name", HeaderValue::from_static("bobby")),
+            ("trace-id", HeaderValue::from_static("1234")),
+            ("tag", HeaderValue::from_static("food")),
+        ])
+        .send(&ManyHeaders)
+        .await
+        .expect("Send RPC message");
+
+    let mut headers = BTreeMap::new();
+    headers.insert("name".to_string(), "bobby".to_string());
+    headers.insert("trace-id".to_string(), "1234".to_string());
+    headers.insert("tag".to_string(), "food".to_string());
+    headers.insert("content-length".to_string(), "4".to_string());
+
+    assert_eq!(response, headers, "Headers should be received",);
+
+    server.shutdown();
+}


### PR DESCRIPTION
Adds the ability to send and receive headers on request payloads.

This does not add support for response headers as I'm still 50/50 if it's worth adding another wrapper type to do this or not and to complicate the message handling.