### PR TITLE
CAKE-63: Cleanup rkyv dependency management and cleanup dataviews

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 [features]
 test-utils = ["datacake-eventual-consistency/test-utils"]
 rkyv = ["datacake-crdt/rkyv-support"]
+rkyv-validation = ["rkyv", "datacake-crdt/rkyv-validation"]
 simulation = ["datacake-rpc/simulation"]
 default = [
     "datacake-crdt",

--- a/datacake-crdt/Cargo.toml
+++ b/datacake-crdt/Cargo.toml
@@ -14,8 +14,9 @@ readme = "README.md"
 [dependencies]
 thiserror = "1.0.33"
 
-rkyv = { version = "0.7.42", features = ["validation"], optional = true }
+rkyv = { version = "0.7.42", features = ["strict", "archive_le"], optional = true }
 
 [features]
 # Enables (de)serialization support for all data types.
 rkyv-support = ["rkyv"]
+rkyv-validation = ["rkyv-support", "rkyv/validation"]

--- a/datacake-crdt/src/orswot.rs
+++ b/datacake-crdt/src/orswot.rs
@@ -33,7 +33,10 @@ pub struct BadState;
 #[derive(Debug, Clone)]
 #[repr(C)]
 #[cfg_attr(feature = "rkyv", derive(Serialize, Deserialize, Archive))]
-#[cfg_attr(feature = "rkyv", archive(compare(PartialEq), check_bytes))]
+#[cfg_attr(
+    all(feature = "rkyv", feature = "rkyv-validation"),
+    archive(compare(PartialEq), check_bytes)
+)]
 pub struct NodeVersions<const N: usize> {
     nodes_max_stamps: [BTreeMap<u8, HLCTimestamp>; N],
     safe_last_stamps: BTreeMap<u8, HLCTimestamp>,
@@ -137,7 +140,10 @@ impl<const N: usize> NodeVersions<N> {
 #[derive(Debug, Default, Clone)]
 #[repr(C)]
 #[cfg_attr(feature = "rkyv", derive(Serialize, Deserialize, Archive))]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
+#[cfg_attr(
+    all(feature = "rkyv", feature = "rkyv-validation"),
+    archive(check_bytes)
+)]
 /// A CRDT which supports purging of deleted entry tombstones.
 ///
 /// This implementation is largely based on the Riak DB implementations
@@ -217,7 +223,7 @@ pub struct OrSWotSet<const N: usize = 1> {
 }
 
 impl<const N: usize> OrSWotSet<N> {
-    #[cfg(feature = "rkyv")]
+    #[cfg(all(feature = "rkyv", feature = "rkyv-validation"))]
     /// Deserializes a [OrSWotSet] from a array of bytes.
     pub fn from_bytes(data: &[u8]) -> Result<Self, BadState> {
         let deserialized = rkyv::from_bytes::<Self>(data).map_err(|_| BadState)?;

--- a/datacake-crdt/src/timestamp.rs
+++ b/datacake-crdt/src/timestamp.rs
@@ -18,7 +18,10 @@ pub const DATACAKE_EPOCH: Duration = Duration::from_secs(1672534861);
 #[derive(Debug, Hash, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(C)]
 #[cfg_attr(feature = "rkyv", derive(Serialize, Deserialize, Archive))]
-#[cfg_attr(feature = "rkyv", archive(compare(PartialEq), check_bytes))]
+#[cfg_attr(
+    all(feature = "rkyv", feature = "rkyv-validation"),
+    archive(compare(PartialEq), check_bytes)
+)]
 #[cfg_attr(feature = "rkyv", archive_attr(repr(C), derive(Debug)))]
 /// A HLC (Hybrid Logical Clock) timestamp implementation.
 ///
@@ -226,6 +229,14 @@ impl HLCTimestamp {
         self.0 = pack(ts_new, c_new, self.node());
 
         Ok(Self::new(ts_new, self.counter(), msg.node()))
+    }
+}
+
+#[cfg(feature = "rkyv-support")]
+impl ArchivedHLCTimestamp {
+    /// Casts the archived HLCTimestamp to the actual HLCTimestamp.
+    pub fn cast(&self) -> HLCTimestamp {
+        HLCTimestamp(self.0.value())
     }
 }
 
@@ -453,7 +464,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "rkyv-support"))]
+#[cfg(all(test, feature = "rkyv-support", feature = "rkyv-validation"))]
 mod rkyv_tests {
     use super::*;
 

--- a/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
+++ b/datacake-eventual-consistency/src/rpc/services/consistency_impl.rs
@@ -79,7 +79,10 @@ where
         &self,
         msg: Request<PutPayload>,
     ) -> Result<HLCTimestamp, Status> {
-        let payload = msg.into_inner().to_owned().map_err(Status::internal)?;
+        let payload = msg
+            .into_inner()
+            .deserialize_view()
+            .map_err(Status::internal)?;
 
         let doc = payload.document;
         let ctx = self.get_put_ctx(payload.ctx)?;
@@ -110,7 +113,10 @@ where
         &self,
         msg: Request<MultiPutPayload>,
     ) -> Result<Self::Reply, Status> {
-        let payload = msg.into_inner().to_owned().map_err(Status::internal)?;
+        let payload = msg
+            .into_inner()
+            .deserialize_view()
+            .map_err(Status::internal)?;
 
         let ctx = self.get_put_ctx(payload.ctx)?;
         self.group.clock().register_ts(payload.timestamp).await;
@@ -139,7 +145,10 @@ where
         &self,
         msg: Request<RemovePayload>,
     ) -> Result<Self::Reply, Status> {
-        let payload = msg.into_inner().to_owned().map_err(Status::internal)?;
+        let payload = msg
+            .into_inner()
+            .deserialize_view()
+            .map_err(Status::internal)?;
 
         self.group.clock().register_ts(payload.timestamp).await;
 
@@ -166,7 +175,10 @@ where
         &self,
         msg: Request<MultiRemovePayload>,
     ) -> Result<Self::Reply, Status> {
-        let payload = msg.into_inner().to_owned().map_err(Status::internal)?;
+        let payload = msg
+            .into_inner()
+            .deserialize_view()
+            .map_err(Status::internal)?;
 
         self.group.clock().register_ts(payload.timestamp).await;
 
@@ -193,7 +205,10 @@ where
         &self,
         msg: Request<BatchPayload>,
     ) -> Result<Self::Reply, Status> {
-        let msg = msg.into_inner().to_owned().map_err(Status::internal)?;
+        let msg = msg
+            .into_inner()
+            .deserialize_view()
+            .map_err(Status::internal)?;
 
         self.group.clock().register_ts(msg.timestamp).await;
 

--- a/datacake-node/src/rpc/services/chitchat_impl.rs
+++ b/datacake-node/src/rpc/services/chitchat_impl.rs
@@ -45,7 +45,7 @@ impl Handler<ChitchatRpcMessage> for ChitchatService {
         &self,
         request: Request<ChitchatRpcMessage>,
     ) -> Result<Self::Reply, Status> {
-        let msg = request.to_owned().map_err(Status::internal)?;
+        let msg = request.deserialize_view().map_err(Status::internal)?;
 
         let from = msg.source;
         self.clock.register_ts(msg.timestamp).await;

--- a/datacake-rpc/src/client.rs
+++ b/datacake-rpc/src/client.rs
@@ -44,7 +44,7 @@ pub type MessageReply<Svc, Msg> =
 ///     type Reply = MyMessage;
 ///
 ///     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-///         Ok(msg.to_owned().unwrap())
+///         Ok(msg.deserialize_view().unwrap())
 ///     }
 /// }
 ///
@@ -302,6 +302,8 @@ where
             .await
             .map_err(|e| Status::internal(e.message()))?;
         let status = DataView::<Status>::using(buffer).map_err(|_| Status::invalid())?;
-        Err(status.to_owned().unwrap_or_else(|_| Status::invalid()))
+        Err(status
+            .deserialize_view()
+            .unwrap_or_else(|_| Status::invalid()))
     }
 }

--- a/datacake-rpc/src/handler.rs
+++ b/datacake-rpc/src/handler.rs
@@ -69,7 +69,7 @@ pub type HandlerKey = u64;
 ///     type Reply = MyMessage;
 ///
 ///     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-///         Ok(msg.to_owned().unwrap())
+///         Ok(msg.deserialize_view().unwrap())
 ///     }
 /// }
 ///
@@ -78,7 +78,7 @@ pub type HandlerKey = u64;
 ///     type Reply = MyOtherMessage;
 ///
 ///     async fn on_message(&self, msg: Request<MyOtherMessage>) -> Result<Self::Reply, Status> {
-///         Ok(msg.to_owned().unwrap())
+///         Ok(msg.deserialize_view().unwrap())
 ///     }
 /// }
 /// ```
@@ -201,7 +201,7 @@ pub trait RpcService: Sized {
 ///     // request buffer, you can use the `to_owned` method which will attempt to
 ///     // deserialize the inner message/view.
 ///     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-///         Ok(msg.to_owned().unwrap())
+///         Ok(msg.deserialize_view().unwrap())
 ///     }
 /// }
 /// ```

--- a/datacake-rpc/src/lib.rs
+++ b/datacake-rpc/src/lib.rs
@@ -60,7 +60,7 @@
 //!     // Our `Request` gives us a zero-copy view to our message, this doesn't actually
 //!     // allocate the message type.
 //!     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-//!         Ok(msg.to_owned().unwrap().name)
+//!         Ok(msg.deserialize_view().unwrap().name)
 //!     }
 //! }
 //!

--- a/datacake-rpc/src/net/status.rs
+++ b/datacake-rpc/src/net/status.rs
@@ -113,7 +113,7 @@ mod tests {
             "Archived value and original value should match"
         );
 
-        let copy: Status = view.to_owned().expect("Deserialize OK");
+        let copy: Status = view.deserialize_view().expect("Deserialize OK");
         assert_eq!(
             copy, status,
             "Deserialized value and original value should match"

--- a/datacake-rpc/src/rkyv_tooling/view.rs
+++ b/datacake-rpc/src/rkyv_tooling/view.rs
@@ -84,7 +84,7 @@ where
 {
     #[inline]
     /// Deserializes the view into it's owned value T.
-    pub fn to_owned(&self) -> Result<T, InvalidView> {
+    pub fn deserialize_view(&self) -> Result<T, InvalidView> {
         self.view
             .deserialize(&mut SharedDeserializeMap::default())
             .map_err(|_| InvalidView)
@@ -199,7 +199,7 @@ mod tests {
         let view: DataView<Demo> = DataView::using(bytes).unwrap();
         assert!(view == demo, "Original and view must match.");
 
-        let value = view.to_owned().unwrap();
+        let value = view.deserialize_view().unwrap();
         assert_eq!(value, demo, "Deserialized and original value should match.")
     }
 }

--- a/datacake-rpc/src/server.rs
+++ b/datacake-rpc/src/server.rs
@@ -40,7 +40,7 @@ use crate::handler::{HandlerKey, OpaqueMessageHandler, RpcService, ServiceRegist
 ///     type Reply = MyMessage;
 ///
 ///     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-///         Ok(msg.to_owned().unwrap())
+///         Ok(msg.deserialize_view().unwrap())
 ///     }
 /// }
 ///

--- a/datacake-rpc/tests/basic.rs
+++ b/datacake-rpc/tests/basic.rs
@@ -33,7 +33,7 @@ impl Handler<MyMessage> for MyService {
     type Reply = String;
 
     async fn on_message(&self, msg: Request<MyMessage>) -> Result<Self::Reply, Status> {
-        Ok(msg.to_owned().unwrap().name)
+        Ok(msg.deserialize_view().unwrap().name)
     }
 }
 

--- a/datacake-rpc/tests/many_messages.rs
+++ b/datacake-rpc/tests/many_messages.rs
@@ -48,7 +48,7 @@ impl Handler<IncCounter> for CountingService {
     type Reply = u64;
 
     async fn on_message(&self, msg: Request<IncCounter>) -> Result<Self::Reply, Status> {
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
 
         let mut lock = self.counters.lock();
         let value = lock.entry(counter.name).or_default();
@@ -63,7 +63,7 @@ impl Handler<DecCounter> for CountingService {
     type Reply = u64;
 
     async fn on_message(&self, msg: Request<DecCounter>) -> Result<Self::Reply, Status> {
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
 
         let mut lock = self.counters.lock();
         let value = lock.entry(counter.name).or_default();

--- a/datacake-rpc/tests/many_services.rs
+++ b/datacake-rpc/tests/many_services.rs
@@ -32,7 +32,7 @@ impl Handler<Payload> for Add5Service {
 
     async fn on_message(&self, msg: Request<Payload>) -> Result<Self::Reply, Status> {
         dbg!(&msg);
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
         Ok(counter.value.saturating_add(5))
     }
 }
@@ -51,7 +51,7 @@ impl Handler<Payload> for Sub5Service {
 
     async fn on_message(&self, msg: Request<Payload>) -> Result<Self::Reply, Status> {
         dbg!(&msg);
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
         Ok(counter.value.saturating_sub(5))
     }
 }

--- a/datacake-rpc/tests/unknown_service.rs
+++ b/datacake-rpc/tests/unknown_service.rs
@@ -32,7 +32,7 @@ impl Handler<Payload> for Add5Service {
 
     async fn on_message(&self, msg: Request<Payload>) -> Result<Self::Reply, Status> {
         dbg!(&msg);
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
         Ok(counter.value.saturating_add(5))
     }
 }
@@ -49,7 +49,7 @@ impl Handler<Payload> for Sub5Service {
 
     async fn on_message(&self, msg: Request<Payload>) -> Result<Self::Reply, Status> {
         dbg!(&msg);
-        let counter = msg.to_owned().expect("Get owned value.");
+        let counter = msg.deserialize_view().expect("Get owned value.");
         Ok(counter.value.saturating_sub(5))
     }
 }

--- a/simulation-tests/tests/rpc.rs
+++ b/simulation-tests/tests/rpc.rs
@@ -371,7 +371,7 @@ impl Handler<MyMessage> for MyService {
             Simulate::None => {},
         }
 
-        Ok(msg.to_owned().unwrap().name)
+        Ok(msg.deserialize_view().unwrap().name)
     }
 }
 


### PR DESCRIPTION
Closes #63 

Removes some of the requirements of rkyv's validation support and improves some of the ergonomics of the `DataView`